### PR TITLE
got rid of double wrapping of an error with the same text

### DIFF
--- a/rest.go
+++ b/rest.go
@@ -48,7 +48,7 @@ func RenderJSONWithHTML(w http.ResponseWriter, r *http.Request, v interface{}) e
 
 	data, err := encodeJSONWithHTML(v)
 	if err != nil {
-		return errors.Wrap(err, "json encoding failed")
+		return err
 	}
 	return RenderJSONFromBytes(w, r, data)
 }


### PR DESCRIPTION
**Current behaviour:**
The error text is:  `json encoding failed: json encoding failed: test error`

**Expected behaviour:**
The error text is: `json encoding failed: test error`