### PR TITLE
Fix type alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ BlackWords middleware doesn't allow user-defined words in the request body.
 
 ## Helpers
 
-- `rest.JSON` - map alias, just for convenience `type JSON map[string]interface{}`
+- `rest.JSON` - map alias, just for convenience `type JSON = map[string]interface{}`
 - `rest.RenderJSON` -  renders json response from `interface{}`
 - `rest.RenderJSONFromBytes` - renders json response from `[]byte`
 - `rest.RenderJSONWithHTML` -  renders json response with html tags and forced `charset=utf-8`

--- a/rest.go
+++ b/rest.go
@@ -9,7 +9,7 @@ import (
 )
 
 // JSON is a map alias, just for convenience
-type JSON map[string]interface{}
+type JSON = map[string]interface{}
 
 // RenderJSON sends data as json
 func RenderJSON(w http.ResponseWriter, r *http.Request, data interface{}) {


### PR DESCRIPTION
Currently JSON is a [type definition](https://golang.org/ref/spec#Type_definitions) and not a [type alias](https://golang.org/ref/spec#Alias_declarations).