### PR TITLE
Make sanitizeQuery() method more robust

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -182,10 +182,10 @@ func (l *Middleware) inLogFlags(f Flag) bool {
 var hideWords = []string{"password", "passwd", "secret", "credentials"}
 
 func (l *Middleware) sanitizeQuery(inp string) string {
-	out := []rune(inp)
+	out := []byte(inp)
 	for _, h := range hideWords {
-		if strings.Contains(strings.ToLower(inp), h+"=") {
-			stPos := strings.Index(strings.ToLower(inp), h+"=") + len(h) + 1
+		if strings.Contains(toLowerLatin(inp), h+"=") {
+			stPos := strings.Index(toLowerLatin(inp), h+"=") + len(h) + 1
 			fnPos := strings.Index(inp[stPos:], "&")
 			if fnPos == -1 {
 				fnPos = len(inp)
@@ -193,8 +193,20 @@ func (l *Middleware) sanitizeQuery(inp string) string {
 				fnPos = stPos + fnPos
 			}
 			for i := stPos; i < fnPos; i++ {
-				out[i] = rune('*')
+				out[i] = byte('*')
 			}
+		}
+	}
+	return string(out)
+}
+
+// Lowercase the letters A-Z
+func toLowerLatin(s string) string {
+	out := []byte(s)
+	offset := byte('a' - 'A')
+	for i, ch := range out {
+		if (ch >= byte('A')) && (ch <= byte('Z')) {
+			out[i] = ch + offset
 		}
 	}
 	return string(out)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -211,6 +211,8 @@ func TestSanitizeReqURL(t *testing.T) {
 		{"/aa/bb?xyz=123&secret=asdfghjk", "/aa/bb?xyz=123&secret=********"},
 		{"/aa/bb?xyz=123&secret=asdfghjk&key=val", "/aa/bb?xyz=123&secret=********&key=val"},
 		{"/aa/bb?xyz=123&secret=asdfghjk&key=val&password=1234", "/aa/bb?xyz=123&secret=********&key=val&password=****"},
+		{"/aa/bb?xyz=тест&password=1234", "/aa/bb?xyz=тест&password=****"},
+		{"/aa/bb?xyz=тест&password=1234&bar=buzz", "/aa/bb?xyz=тест&password=****&bar=buzz"},
 	}
 	l := New()
 	for i, tt := range tbl {


### PR DESCRIPTION
The `sanitizeQuery()` method doesn't handle non-ASCII strings properly. For example:
```
sanitizeQuery("aa/bb?user=тест&password=1234&bar=buzz") == "/aa/bb?user=тест&password=1234****=buzz"
sanitizeQuery("/aa/bb?user=тест&password=1234") == panic
```
Note that in general the property
```
len("some-string") == len(strings.ToLower("some-string"))
```
[doesn't hold](https://groups.google.com/forum/#!topic/golang-dev/pmIaH7RNYSw). Because of that I wrote helper function `toLowerLatin()` that lowercase letters A-Z only and thus holds this property.

Note also that as far as I can see panics in `sanitizeQuery()` method is harmless to Remark42 because of the `Recoverer` middleware. For example the command
```
$ curl -X GET 'http://localhost:8080/auth?user=тест&password=1234'
```
leads only to these log messages:
```
2019/02/04 09:14:10 http: multiple response.WriteHeader calls
2019/02/04 09:14:10.560 [INFO]  {runtime/asm_amd64.s:522} request panic, runtime error: index out of range
2019/02/04 09:14:10.560 [INFO]  {runtime/asm_amd64.s:522} goroutine 57 [running]:
runtime/debug.Stack(0xc00029a460, 0xb001b6, 0x11)
 /usr/local/go/src/runtime/debug/stack.go:24 +0xa7
github.com/umputun/remark/backend/vendor/github.com/go-pkgz/rest.Recoverer.func1.1.1(0x7fcf7f52f0a0, 0xc00029a460, 0xbb17e0, 0xc00036e2a0)
 /go/src/github.com/umputun/remark/backend/vendor/github.com/go-pkgz/rest/middleware.go:51 +0xca
panic(0xa41880, 0x1013740)
 /usr/local/go/src/runtime/panic.go:513 +0x1b9
github.com/umputun/remark/backend/vendor/github.com/go-pkgz/rest/logger.(*Middleware).sanitizeQuery(0xc00011c1e0, 0xc00030c0c0, 0x21, 0xc000412220, 0xc000368c00)
 /go/src/github.com/umputun/remark/backend/vendor/github.com/go-pkgz/rest/logger/logger.go:165 +0x36d
...
```
