### PR TITLE
Refactor log flags

### DIFF
--- a/logger/logger.go
+++ b/logger/logger.go
@@ -70,7 +70,7 @@ func (l *Middleware) Handler(next http.Handler) http.Handler {
 			t2 := time.Now()
 
 			u := *r.URL // shallow copy
-			u.RawQuery = l.sanitizeQuery(u.RawQuery)
+			u.RawQuery = sanitizeQuery(u.RawQuery)
 			rawurl := u.String()
 			if unescURL, err := url.QueryUnescape(rawurl); err == nil {
 				rawurl = unescURL
@@ -159,7 +159,7 @@ var keysToHide = []string{"password", "passwd", "secret", "credentials", "token"
 
 // Hide query values for keysToHide. May change order of query params.
 // May escape unescaped query params.
-func (l *Middleware) sanitizeQuery(rawQuery string) string {
+func sanitizeQuery(rawQuery string) string {
 	// note that we skip non-nil error further
 	query, err := url.ParseQuery(rawQuery)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -76,7 +76,7 @@ func (l *Middleware) Handler(next http.Handler) http.Handler {
 			t2 := time.Now()
 
 			u := *r.URL // shallow copy
-			u.RawQuery = sanitizeQuery(u.RawQuery)
+			u.RawQuery = l.sanitizeQuery(u.RawQuery)
 			rawurl := u.String()
 			if unescURL, err := url.QueryUnescape(rawurl); err == nil {
 				rawurl = unescURL
@@ -187,7 +187,7 @@ var keysToHide = []string{"password", "passwd", "secret", "credentials", "token"
 
 // Hide query values for keysToHide. May change order of query params.
 // May escape unescaped query params.
-func sanitizeQuery(rawQuery string) string {
+func (l *Middleware) sanitizeQuery(rawQuery string) string {
 	// note that we skip non-nil error further
 	query, err := url.ParseQuery(rawQuery)
 

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -237,23 +237,27 @@ func newCustomResponseWriter(w http.ResponseWriter) *customResponseWriter {
 	}
 }
 
+// WriteHeader implements http.ResponseWriter and saves status
 func (c *customResponseWriter) WriteHeader(status int) {
 	c.status = status
 	c.ResponseWriter.WriteHeader(status)
 }
 
+// Write implements http.ResponseWriter and tracks number of bytes written
 func (c *customResponseWriter) Write(b []byte) (int, error) {
 	size, err := c.ResponseWriter.Write(b)
 	c.size += size
 	return size, err
 }
 
+// Flush implements http.Flusher
 func (c *customResponseWriter) Flush() {
 	if f, ok := c.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
 }
 
+// Hijack implements http.Hijacker
 func (c *customResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hj, ok := c.ResponseWriter.(http.Hijacker); ok {
 		return hj.Hijack()

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -16,7 +16,7 @@ import (
 
 var reMultWhtsp = regexp.MustCompile(`[\s\p{Zs}]{2,}`)
 
-// Middleware for logging rest requests
+// Middleware is a logger for rest requests.
 type Middleware struct {
 	prefix      string
 	logBody     bool
@@ -38,14 +38,14 @@ func (s stdBackend) Logf(format string, args ...interface{}) {
 	log.Printf(format, args...)
 }
 
-// Logger returns default logger middleware with REST prefix
+// Logger is default logger middleware with REST prefix
 func Logger(next http.Handler) http.Handler {
 	l := New(Prefix("REST"))
 	return l.Handler(next)
 
 }
 
-// New makes rest Logger with given options
+// New makes rest logger with given options
 func New(options ...Option) *Middleware {
 	res := Middleware{
 		prefix:      "",
@@ -190,7 +190,7 @@ func sanitizeQuery(rawQuery string) string {
 	return query.Encode()
 }
 
-// customResponseWriter implements ResponseWriter and keeping status and size
+// customResponseWriter implements http.ResponseWriter and keeping status and size
 type customResponseWriter struct {
 	http.ResponseWriter
 	status int
@@ -204,27 +204,27 @@ func newCustomResponseWriter(w http.ResponseWriter) *customResponseWriter {
 	}
 }
 
-// WriteHeader implements ResponseWriter and saves status
+// WriteHeader implements http.ResponseWriter and saves status
 func (c *customResponseWriter) WriteHeader(status int) {
 	c.status = status
 	c.ResponseWriter.WriteHeader(status)
 }
 
-// WriteHeader implements ResponseWriter and tracking size
+// Write implements http.ResponseWriter and tracking size
 func (c *customResponseWriter) Write(b []byte) (int, error) {
 	size, err := c.ResponseWriter.Write(b)
 	c.size += size
 	return size, err
 }
 
-// Flush implements ResponseWriter
+// Flush implements http.ResponseWriter
 func (c *customResponseWriter) Flush() {
 	if f, ok := c.ResponseWriter.(http.Flusher); ok {
 		f.Flush()
 	}
 }
 
-// Hijack implements ResponseWriter
+// Hijack implements http.ResponseWriter
 func (c *customResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
 	if hj, ok := c.ResponseWriter.(http.Hijacker); ok {
 		return hj.Hijack()

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -258,9 +258,10 @@ func TestSanitizeReqURL(t *testing.T) {
 		s, _ = url.QueryUnescape(s)
 		return s
 	}
+	var l *Middleware
 	for i, tt := range tbl {
 		t.Run(tt.in, func(t *testing.T) {
-			assert.Equal(t, tt.out, unesc(sanitizeQuery(tt.in)), "check #%d, %s", i, tt.in)
+			assert.Equal(t, tt.out, unesc(l.sanitizeQuery(tt.in)), "check #%d, %s", i, tt.in)
 		})
 	}
 }

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -2,7 +2,6 @@ package logger
 
 import (
 	"bytes"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -182,33 +181,17 @@ func (m *mockLgr) Logf(format string, args ...interface{}) {
 	m.buf.WriteString(fmt.Sprintf(format, args...))
 }
 
-func TestGetBodyAndUser(t *testing.T) {
+func TestGetBody(t *testing.T) {
 	req, err := http.NewRequest("GET", "http://example.com/request", strings.NewReader("body"))
 	require.Nil(t, err)
 
 	l := New()
-	body, user := l.getBodyAndUser(req)
+	body := l.getBody(req)
 	assert.Equal(t, "", body)
-	assert.Equal(t, "", user, "no user")
 
 	l = New(WithBody)
-	body, user = l.getBodyAndUser(req)
+	body = l.getBody(req)
 	assert.Equal(t, "body", body)
-	assert.Equal(t, "", user, "no user")
-
-	l = New(WithUser(func(r *http.Request) (string, error) {
-		return "user1/id1", nil
-	}))
-	body, user = l.getBodyAndUser(req)
-	assert.Equal(t, "", body)
-	assert.Equal(t, `user1/id1`, user, "no user")
-
-	l = New(WithUser(func(r *http.Request) (string, error) {
-		return "", errors.New("err")
-	}))
-	body, user = l.getBodyAndUser(req)
-	assert.Equal(t, "", body)
-	assert.Equal(t, "", user, "no user")
 }
 
 func TestSanitizeReqURL(t *testing.T) {

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -58,10 +58,10 @@ func TestLogger(t *testing.T) {
 		IPfn(func(ip string) string {
 			return ip + "!masked"
 		}),
-		UserFn(func(r *http.Request) (string, error) {
+		WithUser(func(r *http.Request) (string, error) {
 			return "user", nil
 		}),
-		SubjFn(func(r *http.Request) (string, error) {
+		WithSubj(func(r *http.Request) (string, error) {
 			return "subj", nil
 		}),
 	)
@@ -95,10 +95,10 @@ func TestLoggerTraceID(t *testing.T) {
 		IPfn(func(ip string) string {
 			return ip + "!masked"
 		}),
-		UserFn(func(r *http.Request) (string, error) {
+		WithUser(func(r *http.Request) (string, error) {
 			return "user", nil
 		}),
-		SubjFn(func(r *http.Request) (string, error) {
+		WithSubj(func(r *http.Request) (string, error) {
 			return "subj", nil
 		}),
 	)
@@ -196,14 +196,14 @@ func TestGetBodyAndUser(t *testing.T) {
 	assert.Equal(t, "body", body)
 	assert.Equal(t, "", user, "no user")
 
-	l = New(UserFn(func(r *http.Request) (string, error) {
+	l = New(WithUser(func(r *http.Request) (string, error) {
 		return "user1/id1", nil
 	}))
 	body, user = l.getBodyAndUser(req)
 	assert.Equal(t, "", body)
 	assert.Equal(t, `user1/id1`, user, "no user")
 
-	l = New(UserFn(func(r *http.Request) (string, error) {
+	l = New(WithUser(func(r *http.Request) (string, error) {
 		return "", errors.New("err")
 	}))
 	body, user = l.getBodyAndUser(req)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -58,10 +58,10 @@ func TestLogger(t *testing.T) {
 		IPfn(func(ip string) string {
 			return ip + "!masked"
 		}),
-		WithUser(func(r *http.Request) (string, error) {
+		UserFn(func(r *http.Request) (string, error) {
 			return "user", nil
 		}),
-		WithSubj(func(r *http.Request) (string, error) {
+		SubjFn(func(r *http.Request) (string, error) {
 			return "subj", nil
 		}),
 	)
@@ -95,10 +95,10 @@ func TestLoggerTraceID(t *testing.T) {
 		IPfn(func(ip string) string {
 			return ip + "!masked"
 		}),
-		WithUser(func(r *http.Request) (string, error) {
+		UserFn(func(r *http.Request) (string, error) {
 			return "user", nil
 		}),
-		WithSubj(func(r *http.Request) (string, error) {
+		SubjFn(func(r *http.Request) (string, error) {
 			return "subj", nil
 		}),
 	)

--- a/logger/logger_test.go
+++ b/logger/logger_test.go
@@ -232,10 +232,9 @@ func TestSanitizeReqURL(t *testing.T) {
 		s, _ = url.QueryUnescape(s)
 		return s
 	}
-	l := New()
 	for i, tt := range tbl {
 		t.Run(tt.in, func(t *testing.T) {
-			assert.Equal(t, tt.out, unesc(l.sanitizeQuery(tt.in)), "check #%d, %s", i, tt.in)
+			assert.Equal(t, tt.out, unesc(sanitizeQuery(tt.in)), "check #%d, %s", i, tt.in)
 		})
 	}
 }

--- a/logger/options.go
+++ b/logger/options.go
@@ -35,15 +35,15 @@ func IPfn(ipFn func(ip string) string) Option {
 	}
 }
 
-// WithUser triggers user name logging if userFn is not nil.
-func WithUser(userFn func(r *http.Request) (string, error)) Option {
+// UserFn triggers user name logging if userFn is not nil.
+func UserFn(userFn func(r *http.Request) (string, error)) Option {
 	return func(l *Middleware) {
 		l.userFn = userFn
 	}
 }
 
-// WithSubj triggers subject logging if subjFn is not nil.
-func WithSubj(subjFn func(r *http.Request) (string, error)) Option {
+// SubjFn triggers subject logging if subjFn is not nil.
+func SubjFn(subjFn func(r *http.Request) (string, error)) Option {
 	return func(l *Middleware) {
 		l.subjFn = subjFn
 	}

--- a/logger/options.go
+++ b/logger/options.go
@@ -12,7 +12,7 @@ func WithBody(l *Middleware) {
 	l.logBody = true
 }
 
-// MaxBodySize functional option defines the largest body size to log.
+// MaxBodySize sets size of the logged part of the request body.
 func MaxBodySize(max int) Option {
 	return func(l *Middleware) {
 		if max >= 0 {
@@ -21,14 +21,14 @@ func MaxBodySize(max int) Option {
 	}
 }
 
-// Prefix functional option defines log line prefix.
+// Prefix sets log line prefix.
 func Prefix(prefix string) Option {
 	return func(l *Middleware) {
 		l.prefix = prefix
 	}
 }
 
-// IPfn functional option defines ip masking function.
+// IPfn sets IP masking function. If ipFn is nil then IP address will be logged as is.
 func IPfn(ipFn func(ip string) string) Option {
 	return func(l *Middleware) {
 		l.ipFn = ipFn
@@ -42,14 +42,14 @@ func UserFn(userFn func(r *http.Request) (string, error)) Option {
 	}
 }
 
-// SubjFn functional option defines subject function.
+// SubjFn triggers subject logging if subjFn is not nil.
 func SubjFn(userFn func(r *http.Request) (string, error)) Option {
 	return func(l *Middleware) {
 		l.subjFn = userFn
 	}
 }
 
-// Log functional option defines loging backend.
+// Log sets logging backend.
 func Log(log Backend) Option {
 	return func(l *Middleware) {
 		l.log = log

--- a/logger/options.go
+++ b/logger/options.go
@@ -35,15 +35,15 @@ func IPfn(ipFn func(ip string) string) Option {
 	}
 }
 
-// UserFn triggers user name logging if userFn is not nil.
-func UserFn(userFn func(r *http.Request) (string, error)) Option {
+// WithUser triggers user name logging if userFn is not nil.
+func WithUser(userFn func(r *http.Request) (string, error)) Option {
 	return func(l *Middleware) {
 		l.userFn = userFn
 	}
 }
 
-// SubjFn triggers subject logging if subjFn is not nil.
-func SubjFn(userFn func(r *http.Request) (string, error)) Option {
+// WithSubj triggers subject logging if subjFn is not nil.
+func WithSubj(userFn func(r *http.Request) (string, error)) Option {
 	return func(l *Middleware) {
 		l.subjFn = userFn
 	}

--- a/logger/options.go
+++ b/logger/options.go
@@ -43,9 +43,9 @@ func WithUser(userFn func(r *http.Request) (string, error)) Option {
 }
 
 // WithSubj triggers subject logging if subjFn is not nil.
-func WithSubj(userFn func(r *http.Request) (string, error)) Option {
+func WithSubj(subjFn func(r *http.Request) (string, error)) Option {
 	return func(l *Middleware) {
-		l.subjFn = userFn
+		l.subjFn = subjFn
 	}
 }
 

--- a/logger/options.go
+++ b/logger/options.go
@@ -7,10 +7,14 @@ import (
 // Option func type
 type Option func(l *Middleware)
 
-// Flags functional option defines output modes
+// Flags functional option defines output modes.
+// Makes a bitwise OR of the flags provided.
 func Flags(flags ...Flag) Option {
 	return func(l *Middleware) {
-		l.flags = flags
+		l.flags = None
+		for _, f := range flags {
+			l.flags |= f
+		}
 	}
 }
 

--- a/logger/options.go
+++ b/logger/options.go
@@ -7,15 +7,9 @@ import (
 // Option func type
 type Option func(l *Middleware)
 
-// Flags functional option defines output modes.
-// Makes a bitwise OR of the flags provided.
-func Flags(flags ...Flag) Option {
-	return func(l *Middleware) {
-		l.flags = None
-		for _, f := range flags {
-			l.flags |= f
-		}
-	}
+// WithBody triggers request body logging.
+func WithBody(l *Middleware) {
+	l.logBody = true
 }
 
 // MaxBodySize functional option defines the largest body size to log.
@@ -41,7 +35,7 @@ func IPfn(ipFn func(ip string) string) Option {
 	}
 }
 
-// UserFn functional option defines user name function.
+// UserFn triggers user name logging if userFn is not nil.
 func UserFn(userFn func(r *http.Request) (string, error)) Option {
 	return func(l *Middleware) {
 		l.userFn = userFn


### PR DESCRIPTION
IMHO the current implementation of log flags looks quite weird. I propose some improvements to the implementation. If you don't appreciate them - feel free to reject this PR.

Aside from code simplification this PR fixes some bugs/features (let me know if it actually was features - I can adjust the code):
- interpret calls `logger.Flags()` (no arguments) and `logger.Flags([]Flag{}...)` as no logging (i.e. the same as `logger.Flags(logger.None)`). Current implementation in these cases does log record with `user` and `body` parts omitted.
- interpret call of `logger.Flags()` with multiple arguments as call with bitwise OR of the arguments provided. For example: the call `logger.Flags(logger.All, logger.None)` is  interpreted as `logger.Flags(logger.All)`. Current implementation interprets this call as `logger.Flags(logger.None)`.

Note, that as far as I can see current version of Remark42 doesn't make use of these bugs/features.
