### PR TITLE
application/json Content-Type for response from SendErrorJSON, test. …

### DIFF
--- a/httperrors.go
+++ b/httperrors.go
@@ -39,8 +39,7 @@ func SendErrorJSON(w http.ResponseWriter, r *http.Request, l logger.Backend, cod
 	if l != nil {
 		l.Logf("%s", errDetailsMsg(r, code, err, msg))
 	}
-	w.WriteHeader(code)
-	RenderJSON(w, JSON{"error": msg})
+	RenderJSON(w, JSON{"error": msg}, code)
 }
 
 func errDetailsMsg(r *http.Request, code int, err error, msg string) string {

--- a/httperrors_test.go
+++ b/httperrors_test.go
@@ -31,6 +31,8 @@ func TestSendErrorJSON(t *testing.T) {
 	require.Nil(t, err)
 	assert.Equal(t, 500, resp.StatusCode)
 
+	assert.Equal(t, "application/json; charset=utf-8", resp.Header["Content-Type"][0])
+
 	assert.Equal(t, `{"error":"error details 123456"}`+"\n", string(body))
 	t.Log(l.buf.String())
 }
@@ -43,7 +45,7 @@ func TestErrorDetailsMsg(t *testing.T) {
 		msg := errDetailsMsg(req, 500, errors.New("error 500"), "error details 123456")
 		assert.Contains(t, msg, "error details 123456 - error 500 - 500 - 1.2.3.4 - https://example."+
 			"com/test?k1=v1&k2=v2 [caused by")
-		assert.Contains(t, msg, "rest/httperrors_test.go:48 rest.TestErrorDetailsMsg]")
+		assert.Contains(t, msg, "rest/httperrors_test.go:50 rest.TestErrorDetailsMsg]")
 	}
 	callerFn()
 }
@@ -55,7 +57,7 @@ func TestErrorDetailsMsgNoError(t *testing.T) {
 		req.RemoteAddr = "1.2.3.4"
 		msg := errDetailsMsg(req, 500, nil, "error details 123456")
 		assert.Contains(t, msg, "error details 123456 - no error - 500 - 1.2.3.4 - https://example.com/test?k1=v1&k2=v2 [caused by")
-		assert.Contains(t, msg, "rest/httperrors_test.go:60 rest.TestErrorDetailsMsgNoError]")
+		assert.Contains(t, msg, "rest/httperrors_test.go:62 rest.TestErrorDetailsMsgNoError]")
 	}
 	callerFn()
 }

--- a/rest.go
+++ b/rest.go
@@ -13,7 +13,7 @@ import (
 type JSON map[string]interface{}
 
 // RenderJSON sends data as json
-func RenderJSON(w http.ResponseWriter, data interface{}) {
+func RenderJSON(w http.ResponseWriter, data interface{}, code ...int) {
 	buf := &bytes.Buffer{}
 	enc := json.NewEncoder(buf)
 	enc.SetEscapeHTML(true)
@@ -22,6 +22,9 @@ func RenderJSON(w http.ResponseWriter, data interface{}) {
 		return
 	}
 	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	if code != nil {
+		w.WriteHeader(code[0])
+	}
 	_, _ = w.Write(buf.Bytes())
 }
 


### PR DESCRIPTION
…Fixed #13 

This is a kind of hotfix. 

We should probably extract the headers setup process from the `RenderJSON`.