### PR TITLE
make file server with options

### DIFF
--- a/file_server.go
+++ b/file_server.go
@@ -55,19 +55,14 @@ func NewFileServer(public, local string, options ...FSOpt) (*FS, error) {
 		listing: res.enableListing,
 	}
 	f := http.StripPrefix(public, http.FileServer(cfs))
-
-	res.handler = func(w http.ResponseWriter, r *http.Request) {
-		f.ServeHTTP(w, r)
-	}
+	res.handler = func(w http.ResponseWriter, r *http.Request) { f.ServeHTTP(w, r) }
 
 	if !res.enableListing {
 		h, err := custom404Handler(f, res.notFound)
 		if err != nil {
 			return nil, err
 		}
-		res.handler = func(w http.ResponseWriter, r *http.Request) {
-			h.ServeHTTP(w, r)
-		}
+		res.handler = func(w http.ResponseWriter, r *http.Request) { h.ServeHTTP(w, r) }
 	}
 
 	return &res, nil

--- a/file_server.go
+++ b/file_server.go
@@ -24,7 +24,7 @@ type FS struct {
 }
 
 // NewFileServer creates file server with optional spa mode and optional direcroty listing (disabled by default)
-func NewFileServer(public, local string, options ...FSOpt) (*FS, error) {
+func NewFileServer(public, local string, options ...FsOpt) (*FS, error) {
 	res := FS{
 		public:        public,
 		notFound:      nil,
@@ -85,8 +85,8 @@ func (fs *FS) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	fs.handler(w, r)
 }
 
-// FSOpt defines functional option type
-type FSOpt func(fs *FS) error
+// FsOpt defines functional option type
+type FsOpt func(fs *FS) error
 
 // FsOptSPA turns on SPA mode returning "/index.html" on not-found
 func FsOptSPA(fs *FS) error {
@@ -101,7 +101,7 @@ func FsOptListing(fs *FS) error {
 }
 
 // FsOptCustom404 sets custom 404 reader
-func FsOptCustom404(fr io.Reader) FSOpt {
+func FsOptCustom404(fr io.Reader) FsOpt {
 	return func(fs *FS) error {
 		fs.notFound = fr
 		return nil

--- a/file_server.go
+++ b/file_server.go
@@ -131,17 +131,24 @@ func (cfs customFS) Open(name string) (http.File, error) {
 		return nil, err
 	}
 
-	s, err := f.Stat()
+	finfo, err := f.Stat()
 	if err != nil {
 		return nil, err
 	}
 
-	if s.IsDir() && !cfs.listing {
+	if finfo.IsDir() {
 		index := strings.TrimSuffix(name, "/") + "/index.html"
-		if _, err := cfs.fs.Open(index); err != nil {
-			return nil, err
+		if _, err := cfs.fs.Open(index); err == nil { // index.html will be served if found
+			return f, nil
+		}
+		// no index.html in directory
+		if !cfs.listing { // listing disabled
+			if _, err := cfs.fs.Open(index); err != nil {
+				return nil, err
+			}
 		}
 	}
+
 	return f, nil
 }
 

--- a/file_server.go
+++ b/file_server.go
@@ -10,52 +10,111 @@ import (
 	"strings"
 )
 
-// FileServer returns http.FileServer handler to serve static files from a http.FileSystem,
-// prevents directory listing.
+// FileServer provides http.FileServer handler to serve static files from a http.FileSystem,
+// prevents directory listing by default and supports spa-friendly mode (off by default) returning /index.html on 404.
 // - public defines base path of the url, i.e. for http://example.com/static/* it should be /static
 // - local for the local path to the root of the served directory
 // - notFound is the reader for the custom 404 html, can be nil for default
-func FileServer(public, local string, notFound io.Reader) (http.Handler, error) {
+type FileServer struct {
+	public, root  string
+	notFound      io.Reader
+	isSpa         bool
+	enableListing bool
+	handler       http.HandlerFunc
+}
+
+// NewFileServer creates file server with optional spa mode and optional direcroty listing (disabled by default)
+func NewFileServer(public, local string, options ...FSOpt) (*FileServer, error) {
+	res := FileServer{
+		public:        public,
+		notFound:      nil,
+		isSpa:         false,
+		enableListing: false,
+	}
 
 	root, err := filepath.Abs(local)
 	if err != nil {
 		return nil, fmt.Errorf("can't get absolute path for %s: %w", local, err)
 	}
+	res.root = root
+
 	if _, err = os.Stat(root); os.IsNotExist(err) {
 		return nil, fmt.Errorf("local path %s doesn't exist: %w", root, err)
 	}
 
-	fs := http.StripPrefix(public, http.FileServer(noDirListingFS{http.Dir(root), false}))
-	return custom404Handler(fs, notFound)
-}
-
-// FileServerSPA returns FileServer as above, but instead of no-found returns /local/index.html
-func FileServerSPA(public, local string, notFound io.Reader) (http.Handler, error) {
-
-	root, err := filepath.Abs(local)
-	if err != nil {
-		return nil, fmt.Errorf("can't get absolute path for %s: %w", local, err)
-	}
-	if _, err = os.Stat(root); os.IsNotExist(err) {
-		return nil, fmt.Errorf("local path %s doesn't exist: %w", root, err)
+	for _, opt := range options {
+		err = opt(&res)
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	fs := http.StripPrefix(public, http.FileServer(noDirListingFS{http.Dir(root), true}))
-	return custom404Handler(fs, notFound)
+	cfs := customFS{
+		fs:      http.Dir(root),
+		spa:     res.isSpa,
+		listing: res.enableListing,
+	}
+	f := http.StripPrefix(public, http.FileServer(cfs))
+
+	res.handler = func(w http.ResponseWriter, r *http.Request) {
+		f.ServeHTTP(w, r)
+	}
+
+	if !res.enableListing {
+		h, err := custom404Handler(f, res.notFound)
+		if err != nil {
+			return nil, err
+		}
+		res.handler = func(w http.ResponseWriter, r *http.Request) {
+			h.ServeHTTP(w, r)
+		}
+	}
+
+	return &res, nil
 }
 
-type noDirListingFS struct {
-	fs  http.FileSystem
-	spa bool
+// ServeHTTP makes FileServer compatible with http.Handler interface
+func (fs *FileServer) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	fs.handler(w, r)
+}
+
+// FSOpt defines functional option type
+type FSOpt func(fs *FileServer) error
+
+// FsOptSPA turns on SPA mode returning "/index.html" on not-found
+func FsOptSPA(fs *FileServer) error {
+	fs.isSpa = true
+	return nil
+}
+
+// FsOptListing turns on directory listing
+func FsOptListing(fs *FileServer) error {
+	fs.enableListing = true
+	return nil
+}
+
+// FsOptCustom404 sets custom 404 reader
+func FsOptCustom404(fr io.Reader) FSOpt {
+	return func(fs *FileServer) error {
+		fs.notFound = fr
+		return nil
+	}
+}
+
+// customFS wraps http.FileSystem with spa and no-listing optional support
+type customFS struct {
+	fs      http.FileSystem
+	spa     bool
+	listing bool
 }
 
 // Open file on FS, for directory enforce index.html and fail on a missing index
-func (fs noDirListingFS) Open(name string) (http.File, error) {
+func (cfs customFS) Open(name string) (http.File, error) {
 
-	f, err := fs.fs.Open(name)
+	f, err := cfs.fs.Open(name)
 	if err != nil {
-		if fs.spa {
-			return fs.fs.Open("/index.html")
+		if cfs.spa {
+			return cfs.fs.Open("/index.html")
 		}
 		return nil, err
 	}
@@ -65,9 +124,9 @@ func (fs noDirListingFS) Open(name string) (http.File, error) {
 		return nil, err
 	}
 
-	if s.IsDir() {
+	if s.IsDir() && !cfs.listing {
 		index := strings.TrimSuffix(name, "/") + "/index.html"
-		if _, err := fs.fs.Open(index); err != nil {
+		if _, err := cfs.fs.Open(index); err != nil {
 			return nil, err
 		}
 	}

--- a/file_server.go
+++ b/file_server.go
@@ -69,13 +69,13 @@ func NewFileServer(public, local string, options ...FsOpt) (*FS, error) {
 }
 
 // FileServer is a shortcut for making FS with listing disabled and the custom noFound reader (can be nil).
-// The method is for back-compatibility only and user should use the universal NewFileServer instead
+// Deprecated: the method is for back-compatibility only and user should use the universal NewFileServer instead
 func FileServer(public, local string, notFound io.Reader) (http.Handler, error) {
 	return NewFileServer(public, local, FsOptCustom404(notFound))
 }
 
 // FileServerSPA is a shortcut for making FS with SPA-friendly handling of 404, listing disabled and the custom noFound reader (can be nil).
-// The method is for back-compatibility only and user should use the universal NewFileServer instead
+// Deprecated: the method is for back-compatibility only and user should use the universal NewFileServer instead
 func FileServerSPA(public, local string, notFound io.Reader) (http.Handler, error) {
 	return NewFileServer(public, local, FsOptCustom404(notFound), FsOptSPA)
 }


### PR DESCRIPTION
The current way to make FileServer is a little bit awkward with an optional reader for 404 (can be nil) and the second FileServerSPA where the reader passed too. It also doesn't allow to turn directory listing on as we suppress it.

This PR adds func options for the `NewFileServer` constructor with several options:

- FsOptSPA - turns SPA mode on
- FsOptListing - turns directroy listing on
- FsOptCustom404 - sets custom not-found page reader

Both existing methods (FileServer and FileServerSPA) are still supported for back compatibilty