### PR TITLE
Add IPv4 link-local address to private ranges detector, update list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,12 +1,9 @@
 linters-settings:
   govet:
-    check-shadowing: true
-  golint:
-    min-confidence: 0
+    enable:
+      - shadow
   gocyclo:
     min-complexity: 15
-  maligned:
-    suggest-new: true
   dupl:
     threshold: 100
   goconst:
@@ -26,17 +23,17 @@ linters-settings:
 
 linters:
   enable:
-    - megacheck
+    - staticcheck
+    - gosimple
     - revive
     - govet
     - unconvert
-    - megacheck
-    - gas
+    - unused
+    - gosec
     - gocyclo
     - dupl
     - misspell
     - unparam
-    - unused
     - typecheck
     - ineffassign
     - stylecheck
@@ -44,25 +41,15 @@ linters:
     - exportloopref
     - gocritic
     - nakedret
-    - gosimple
     - prealloc
   fast: false
   disable-all: true
-
-run:
-  output:
-    format: tab
-  skip-dirs:
-    - vendor
 
 issues:
   exclude-rules:
     - text: 'Deferring unsafe method "Close" on type "io.ReadCloser"'
       linters:
         - gosec
-    - text: "should have a package comment, unless it's in another file for this package"
-      linters:
-        - golint
     - path: _test\.go
       linters:
         - dupl

--- a/benchmarks.go
+++ b/benchmarks.go
@@ -55,10 +55,10 @@ func NewBenchmarks() *Benchmarks {
 // Default is 15 minutes. The increase of this range will change memory utilization as each second of the range
 // kept as benchData aggregate. The default means 15*60 = 900 seconds of data aggregate.
 // Larger range allows for longer time periods to be benchmarked.
-func (b *Benchmarks) WithTimeRange(max time.Duration) *Benchmarks {
+func (b *Benchmarks) WithTimeRange(maximum time.Duration) *Benchmarks {
 	b.lock.Lock()
 	defer b.lock.Unlock()
-	b.maxTimeRange = max
+	b.maxTimeRange = maximum
 	return b
 }
 

--- a/logger/options.go
+++ b/logger/options.go
@@ -13,10 +13,10 @@ func WithBody(l *Middleware) {
 }
 
 // MaxBodySize sets size of the logged part of the request body.
-func MaxBodySize(max int) Option {
+func MaxBodySize(maximum int) Option {
 	return func(l *Middleware) {
-		if max >= 0 {
-			l.maxBodySize = max
+		if maximum >= 0 {
+			l.maxBodySize = maximum
 		}
 	}
 }

--- a/realip/real.go
+++ b/realip/real.go
@@ -14,15 +14,22 @@ type ipRange struct {
 	end   net.IP
 }
 
+// privateRanges contains the list of private and special-use IP ranges.
+// reference: https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml
 var privateRanges = []ipRange{
+	// IPv4 Private Ranges
 	{start: net.ParseIP("10.0.0.0"), end: net.ParseIP("10.255.255.255")},
-	{start: net.ParseIP("100.64.0.0"), end: net.ParseIP("100.127.255.255")},
 	{start: net.ParseIP("172.16.0.0"), end: net.ParseIP("172.31.255.255")},
-	{start: net.ParseIP("192.0.0.0"), end: net.ParseIP("192.0.0.255")},
 	{start: net.ParseIP("192.168.0.0"), end: net.ParseIP("192.168.255.255")},
+	// IPv4 Link-Local
+	{start: net.ParseIP("169.254.0.0"), end: net.ParseIP("169.254.255.255")},
+	// IPv4 Shared Address Space (RFC 6598)
+	{start: net.ParseIP("100.64.0.0"), end: net.ParseIP("100.127.255.255")},
+	// IPv4 Benchmarking (RFC 2544)
 	{start: net.ParseIP("198.18.0.0"), end: net.ParseIP("198.19.255.255")},
-	{start: net.ParseIP("::1"), end: net.ParseIP("::1")},
+	// IPv6 Unique Local Addresses (ULA)
 	{start: net.ParseIP("fc00::"), end: net.ParseIP("fdff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")},
+	// IPv6 Link-local Addresses
 	{start: net.ParseIP("fe80::"), end: net.ParseIP("febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff")},
 }
 


### PR DESCRIPTION
169.254.0.0/16 is this new range is the same as fe80::/10 for IPv6.

Also, add comments to each entry according to provided link and replace
192.0.0.0/24 with more specific prefixes according to standard.

Originally found using Claude 3.5 Sonnet, but ChatGPT 4o told me that some addresses might be incorrect and then I used https://www.iana.org/assignments/iana-ipv4-special-registry/iana-ipv4-special-registry.xhtml as a reference to get a corrected list.