### PR TITLE
Return Unauthorized instead of Forbidden in the BasicAuth middleware

### DIFF
--- a/basic_auth.go
+++ b/basic_auth.go
@@ -20,7 +20,7 @@ func BasicAuth(checker func(user, passwd string) bool) func(http.Handler) http.H
 				return
 			}
 			if !checker(u, p) {
-				w.WriteHeader(http.StatusForbidden)
+				w.WriteHeader(http.StatusUnauthorized)
 				return
 			}
 			h.ServeHTTP(w, r.WithContext(context.WithValue(r.Context(), contextKey(baContextKey), true)))

--- a/basic_auth_test.go
+++ b/basic_auth_test.go
@@ -53,7 +53,7 @@ func TestBasicAuth(t *testing.T) {
 		req.SetBasicAuth("dev", "bad")
 		resp, err := client.Do(req)
 		require.NoError(t, err)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	}
 }
 
@@ -95,7 +95,7 @@ func TestBasicAuthWithUserPasswd(t *testing.T) {
 		req.SetBasicAuth("dev", "bad")
 		resp, err := client.Do(req)
 		require.NoError(t, err)
-		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+		assert.Equal(t, http.StatusUnauthorized, resp.StatusCode)
 	}
 }
 


### PR DESCRIPTION
BasicAuth middleware should return 401 Unauthorized no matter `Authorization` header isn't present or has incorrect data.

> A 401 Unauthorized is similar to the [403 Forbidden](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403) response, except that a 403 is returned when a request contains valid credentials, but the client does not have permissions to perform a certain action.
Source: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/401

In the case of 403 Forbidden, the browser doesn't ask to re-enter the credentials.