### PR TITLE
middleware wrapping tollboth/v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,9 @@ jobs:
           TZ: "America/Chicago"
 
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v4
         with:
-          version: v1.59
+          version: v1.63
 
       - name: install goveralls
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.61
+          version: v1.59
 
       - name: install goveralls
         run: |

--- a/README.md
+++ b/README.md
@@ -181,6 +181,34 @@ example with chi router:
 	
 	router.Use(rest.Reject(http.StatusBadRequest, "X-Request-Id header is required", rejectFn))
 ```
+### Limiter (tollbooth) middleware
+
+Limiter middleware is a rate limiter that limits the number of requests a client can make in a given time window. 
+It wraps the [tollbooth](https://github.com/didip/tollbooth) library.
+
+example with stdlib router:
+
+```go
+    router := http.NewServeMux()
+    limiter := tollbooth.NewLimiter(1, nil)
+    
+    router.Handle("/api", tollbooth.LimitHandler(limiter, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte("Hello, World!"))
+    })))
+``` 
+
+example with [routegroup](https://github.com/go-pkgz/routegroup):
+
+```go
+    router := routegroup.New(http.NewServeMux())
+    limiter := tollbooth.NewLimiter(1, nil)
+	router.Use(rest.Limiter(limiter))
+	
+    router.HandleFunc("/api", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+        w.Write([]byte("Hello, World!"))
+    }))
+```
+By default, the middleware uses `RemoteAddr` lookup to get the client's IP address. This can be changed by `SetIPLookup` of the limiter itself. For more details see [tollbooth docs](https://github.com/didip/tollbooth?tab=readme-ov-file#features)
 
 ### BasicAuth middleware family
 

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,14 @@ module github.com/go-pkgz/rest
 go 1.21
 
 require (
+	github.com/didip/tollbooth/v8 v8.0.0
 	github.com/stretchr/testify v1.10.0
 	golang.org/x/crypto v0.31.0
 )
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/go-pkgz/expirable-cache/v3 v3.0.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	golang.org/x/sys v0.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,11 @@
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/didip/tollbooth/v8 v8.0.0 h1:AMr7m7TlXLpxAgKfshyoBMLuq6uv6EU3CZ9HBAGQIvQ=
+github.com/didip/tollbooth/v8 v8.0.0/go.mod h1:oEd9l+ep373d7DmvKLc0a5gasPOev2mTewi6KPQBGJ4=
+github.com/go-pkgz/expirable-cache/v3 v3.0.0 h1:u3/gcu3sabLYiTCevoRKv+WzjIn5oo7P8XtiXBeRDLw=
+github.com/go-pkgz/expirable-cache/v3 v3.0.0/go.mod h1:2OQiDyEGQalYecLWmXprm3maPXeVb5/6/X7yRPYTzec=
+github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
+github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -1,0 +1,40 @@
+package rest
+
+import (
+	"net/http"
+
+	"github.com/didip/tollbooth/v8"
+	"github.com/didip/tollbooth/v8/limiter"
+)
+
+// based on https://github.com/didip/tollbooth_chi/blob/master/tollbooth_chi.go
+// added support of v8 and simplified, removed chi dependency
+// one notable difference is that this middleware sets IP lookup to RemoteAddr by default,
+// however, it can be overridden by setting it in the limiter
+
+// LimitHandler wraps http.Handler with tollbooth limiter
+func LimitHandler(lmt *limiter.Limiter) func(http.Handler) http.Handler {
+	// // set IP lookup only if not set
+	if lmt.GetIPLookup().Name == "" {
+		lmt.SetIPLookup(limiter.IPLookup{Name: "RemoteAddr"})
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			select {
+			case <-r.Context().Done():
+				http.Error(w, "Context was canceled", http.StatusServiceUnavailable)
+				return
+			default:
+				if httpError := tollbooth.LimitByRequest(lmt, w, r); httpError != nil {
+					lmt.ExecOnLimitReached(w, r)
+					w.Header().Add("Content-Type", lmt.GetMessageContentType())
+					w.WriteHeader(httpError.StatusCode)
+					w.Write([]byte(httpError.Message))
+					return
+				}
+				next.ServeHTTP(w, r)
+			}
+		})
+	}
+}

--- a/tollbooth.go
+++ b/tollbooth.go
@@ -30,7 +30,7 @@ func LimitHandler(lmt *limiter.Limiter) func(http.Handler) http.Handler {
 					lmt.ExecOnLimitReached(w, r)
 					w.Header().Add("Content-Type", lmt.GetMessageContentType())
 					w.WriteHeader(httpError.StatusCode)
-					w.Write([]byte(httpError.Message))
+					w.Write([]byte(httpError.Message)) //nolint:gosec // not much we can do here with failed write
 					return
 				}
 				next.ServeHTTP(w, r)

--- a/tollbooth_test.go
+++ b/tollbooth_test.go
@@ -1,0 +1,146 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/didip/tollbooth/v8"
+	"github.com/didip/tollbooth/v8/limiter"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLimitHandler(t *testing.T) {
+
+	t.Run("basic request", func(t *testing.T) {
+		lmt := tollbooth.NewLimiter(1, nil)
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		wrapped := LimitHandler(lmt)(handler)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r.RemoteAddr = "127.0.0.1:12345"
+		wrapped.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("rate limit exceeded", func(t *testing.T) {
+		lmt := tollbooth.NewLimiter(0.1, nil) // only allow one request per 10 seconds
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		wrapped := LimitHandler(lmt)(handler)
+
+		// first request
+		w1 := httptest.NewRecorder()
+		r1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r1.RemoteAddr = "127.0.0.1:12345"
+		wrapped.ServeHTTP(w1, r1)
+
+		// immediate second request should fail
+		w2 := httptest.NewRecorder()
+		r2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r2.RemoteAddr = "127.0.0.1:12345"
+		wrapped.ServeHTTP(w2, r2)
+
+		assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+		assert.Contains(t, w2.Body.String(), "maximum request limit")
+	})
+
+	t.Run("context cancelled", func(t *testing.T) {
+		lmt := tollbooth.NewLimiter(1, nil)
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		wrapped := LimitHandler(lmt)(handler)
+		w := httptest.NewRecorder()
+		r := httptest.NewRequest(http.MethodGet, "/test", nil)
+		ctx, cancel := context.WithCancel(r.Context())
+		cancel()
+		r = r.WithContext(ctx)
+		wrapped.ServeHTTP(w, r)
+		assert.Equal(t, http.StatusServiceUnavailable, w.Code)
+		assert.Contains(t, w.Body.String(), "Context was canceled")
+	})
+
+	t.Run("custom error handler", func(t *testing.T) {
+		lmt := tollbooth.NewLimiter(0.1, nil) // only allow one request per 10 seconds
+		customMsg := "custom limit reached"
+		lmt.SetMessage(customMsg)
+
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		wrapped := LimitHandler(lmt)(handler)
+
+		// first request
+		w1 := httptest.NewRecorder()
+		r1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r1.RemoteAddr = "127.0.0.1:12345"
+		wrapped.ServeHTTP(w1, r1)
+
+		// immediate second request should fail
+		w2 := httptest.NewRecorder()
+		r2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r2.RemoteAddr = "127.0.0.1:12345"
+		wrapped.ServeHTTP(w2, r2)
+
+		assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+		assert.Contains(t, w2.Body.String(), customMsg)
+	})
+
+	t.Run("default IP lookup", func(t *testing.T) {
+		lmt := tollbooth.NewLimiter(0.1, nil)
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		wrapped := LimitHandler(lmt)(handler)
+
+		// first request
+		w1 := httptest.NewRecorder()
+		r1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r1.RemoteAddr = "127.0.0.1:12345"
+		wrapped.ServeHTTP(w1, r1)
+
+		// second request should fail as default RemoteAddr will be used
+		w2 := httptest.NewRecorder()
+		r2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r2.RemoteAddr = "127.0.0.1:12345"
+		wrapped.ServeHTTP(w2, r2)
+
+		assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+	})
+
+	t.Run("custom IP lookup", func(t *testing.T) {
+		lmt := tollbooth.NewLimiter(0.1, nil)
+		lmt.SetIPLookup(limiter.IPLookup{Name: "X-Real-IP"})
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		})
+		wrapped := LimitHandler(lmt)(handler)
+
+		// first request
+		w1 := httptest.NewRecorder()
+		r1 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r1.Header.Set("X-Real-IP", "5.5.5.5")
+		wrapped.ServeHTTP(w1, r1)
+
+		// second request with same X-Real-IP should fail
+		w2 := httptest.NewRecorder()
+		r2 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r2.Header.Set("X-Real-IP", "5.5.5.5")
+		wrapped.ServeHTTP(w2, r2)
+
+		assert.Equal(t, http.StatusTooManyRequests, w2.Code)
+
+		// request with different X-Real-IP should pass
+		w3 := httptest.NewRecorder()
+		r3 := httptest.NewRequest(http.MethodGet, "/test", nil)
+		r3.Header.Set("X-Real-IP", "6.6.6.6")
+		wrapped.ServeHTTP(w3, r3)
+
+		assert.Equal(t, http.StatusOK, w3.Code)
+	})
+}


### PR DESCRIPTION
This PR adds a middleware wrapper for [`tollbooth/v8` limiter](https://github.com/didip/tollbooth).

The wrapper makes it possible to use the limiter with any router supporting the stdlib http-related signatures. The code is inspired by [tollbooth_chi](https://github.com/didip/tollbooth_chi) but has several notable differences:

-  It works with v8 instead of v7 of the `tollbooth`.
-  The chi dependency has been removed.
-  The actual handler code is "inlined" and doesn't need to create an internal `limiterWrapper` anymore.
-  It sets IP lookup to `RemoteAddr` by default, only if not set by the limiter itself.