### PR TITLE
Add security middlewares: Secure, CORS, CSRF, CleanPath, StripSlashes

### DIFF
--- a/cors.go
+++ b/cors.go
@@ -1,0 +1,180 @@
+package rest
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// CORSConfig defines CORS middleware configuration.
+// Use CorsOpt functions to customize.
+type CORSConfig struct {
+	// AllowedOrigins is a list of origins that may access the resource.
+	// use "*" to allow all origins (not recommended with credentials).
+	// default: ["*"]
+	AllowedOrigins []string
+	// AllowedMethods is a list of methods the client is allowed to use.
+	// default: GET, POST, PUT, PATCH, DELETE, OPTIONS, HEAD
+	AllowedMethods []string
+	// AllowedHeaders is a list of headers the client is allowed to send.
+	// default: Accept, Content-Type, Authorization, X-Requested-With
+	AllowedHeaders []string
+	// ExposedHeaders is a list of headers that are safe to expose to the client.
+	// default: empty
+	ExposedHeaders []string
+	// AllowCredentials indicates whether the request can include credentials.
+	// when true, AllowedOrigins cannot be "*" (browser security restriction).
+	// default: false
+	AllowCredentials bool
+	// MaxAge indicates how long (in seconds) the results of a preflight can be cached.
+	// default: 0 (no caching)
+	MaxAge int
+}
+
+// CorsOpt is a functional option for CORSConfig
+type CorsOpt func(*CORSConfig)
+
+// defaultCORSConfig returns config with sensible defaults
+func defaultCORSConfig() CORSConfig {
+	return CORSConfig{
+		AllowedOrigins:   []string{"*"},
+		AllowedMethods:   []string{"GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS", "HEAD"},
+		AllowedHeaders:   []string{"Accept", "Content-Type", "Authorization", "X-Requested-With"},
+		ExposedHeaders:   []string{},
+		AllowCredentials: false,
+		MaxAge:           0,
+	}
+}
+
+// CorsAllowedOrigins sets the list of allowed origins.
+// Use "*" to allow all origins (not recommended with credentials).
+func CorsAllowedOrigins(origins ...string) CorsOpt {
+	return func(c *CORSConfig) {
+		c.AllowedOrigins = origins
+	}
+}
+
+// CorsAllowedMethods sets the list of allowed HTTP methods.
+func CorsAllowedMethods(methods ...string) CorsOpt {
+	return func(c *CORSConfig) {
+		c.AllowedMethods = methods
+	}
+}
+
+// CorsAllowedHeaders sets the list of allowed request headers.
+func CorsAllowedHeaders(headers ...string) CorsOpt {
+	return func(c *CORSConfig) {
+		c.AllowedHeaders = headers
+	}
+}
+
+// CorsExposedHeaders sets the list of headers exposed to the client.
+func CorsExposedHeaders(headers ...string) CorsOpt {
+	return func(c *CORSConfig) {
+		c.ExposedHeaders = headers
+	}
+}
+
+// CorsAllowCredentials enables or disables credentials.
+// When true, AllowedOrigins cannot be "*".
+func CorsAllowCredentials(allow bool) CorsOpt {
+	return func(c *CORSConfig) {
+		c.AllowCredentials = allow
+	}
+}
+
+// CorsMaxAge sets how long (in seconds) preflight results can be cached.
+func CorsMaxAge(seconds int) CorsOpt {
+	return func(c *CORSConfig) {
+		c.MaxAge = seconds
+	}
+}
+
+// CORS is middleware that handles Cross-Origin Resource Sharing.
+// It handles preflight OPTIONS requests and sets appropriate headers.
+// By default allows all origins with common methods and headers.
+func CORS(opts ...CorsOpt) func(http.Handler) http.Handler {
+	cfg := defaultCORSConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	// pre-compute joined strings for performance
+	methodsStr := strings.Join(cfg.AllowedMethods, ", ")
+	headersStr := strings.Join(cfg.AllowedHeaders, ", ")
+	exposedStr := strings.Join(cfg.ExposedHeaders, ", ")
+
+	// check if wildcard is used
+	allowAll := len(cfg.AllowedOrigins) == 1 && cfg.AllowedOrigins[0] == "*"
+
+	// build origin lookup for O(1) check (only when not allowing all)
+	var originSet map[string]bool
+	if !allowAll {
+		originSet = make(map[string]bool, len(cfg.AllowedOrigins))
+		for _, o := range cfg.AllowedOrigins {
+			originSet[strings.ToLower(o)] = true
+		}
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			origin := r.Header.Get("Origin")
+
+			// no origin header means same-origin or non-browser request
+			if origin == "" {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// check if origin is allowed
+			var allowed bool
+			if allowAll {
+				allowed = true
+			} else {
+				allowed = originSet[strings.ToLower(origin)]
+			}
+			if !allowed {
+				// origin not allowed, proceed without CORS headers
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			// set Vary header for caching
+			w.Header().Add("Vary", "Origin")
+
+			// set allowed origin
+			if allowAll && !cfg.AllowCredentials {
+				w.Header().Set("Access-Control-Allow-Origin", "*")
+			} else {
+				// reflect the specific origin (required for credentials)
+				w.Header().Set("Access-Control-Allow-Origin", origin)
+			}
+
+			// set credentials header if enabled
+			if cfg.AllowCredentials {
+				w.Header().Set("Access-Control-Allow-Credentials", "true")
+			}
+
+			// handle preflight request
+			if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
+				// preflight request
+				w.Header().Set("Access-Control-Allow-Methods", methodsStr)
+				w.Header().Set("Access-Control-Allow-Headers", headersStr)
+
+				if cfg.MaxAge > 0 {
+					w.Header().Set("Access-Control-Max-Age", strconv.Itoa(cfg.MaxAge))
+				}
+
+				w.WriteHeader(http.StatusNoContent)
+				return
+			}
+
+			// actual request - set exposed headers
+			if exposedStr != "" {
+				w.Header().Set("Access-Control-Expose-Headers", exposedStr)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/cors_test.go
+++ b/cors_test.go
@@ -1,0 +1,295 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCORS_Defaults(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	CORS()(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Empty(t, resp.Header.Get("Access-Control-Allow-Credentials"))
+}
+
+func TestCORS_NoOrigin(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	// no Origin header
+	w := httptest.NewRecorder()
+
+	CORS()(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+}
+
+func TestCORS_Preflight(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		t.Error("handler should not be called for preflight")
+	})
+
+	req := httptest.NewRequest("OPTIONS", "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	w := httptest.NewRecorder()
+
+	CORS()(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+	assert.Equal(t, "*", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Methods"), "POST")
+	assert.Contains(t, resp.Header.Get("Access-Control-Allow-Headers"), "Content-Type")
+}
+
+func TestCORS_PreflightWithMaxAge(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
+
+	req := httptest.NewRequest("OPTIONS", "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "PUT")
+	w := httptest.NewRecorder()
+
+	CORS(CorsMaxAge(3600))(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, "3600", resp.Header.Get("Access-Control-Max-Age"))
+}
+
+func TestCORS_SpecificOrigins(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("allowed origin", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.Header.Set("Origin", "https://allowed.com")
+		w := httptest.NewRecorder()
+
+		CORS(CorsAllowedOrigins("https://allowed.com", "https://also-allowed.com"))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "https://allowed.com", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("disallowed origin", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.Header.Set("Origin", "https://evil.com")
+		w := httptest.NewRecorder()
+
+		CORS(CorsAllowedOrigins("https://allowed.com"))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+
+	t.Run("case insensitive", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.Header.Set("Origin", "HTTPS://ALLOWED.COM")
+		w := httptest.NewRecorder()
+
+		CORS(CorsAllowedOrigins("https://allowed.com"))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "HTTPS://ALLOWED.COM", resp.Header.Get("Access-Control-Allow-Origin"))
+	})
+}
+
+func TestCORS_Credentials(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("with credentials reflects origin", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.Header.Set("Origin", "https://app.example.com")
+		w := httptest.NewRecorder()
+
+		CORS(
+			CorsAllowedOrigins("https://app.example.com"),
+			CorsAllowCredentials(true),
+		)(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "https://app.example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+	})
+
+	t.Run("wildcard with credentials reflects origin", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.Header.Set("Origin", "https://any.example.com")
+		w := httptest.NewRecorder()
+
+		CORS(CorsAllowCredentials(true))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		// with credentials, must reflect origin, not "*"
+		assert.Equal(t, "https://any.example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+	})
+}
+
+func TestCORS_CustomMethods(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
+
+	req := httptest.NewRequest("OPTIONS", "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "PATCH")
+	w := httptest.NewRecorder()
+
+	CORS(CorsAllowedMethods("GET", "PATCH"))(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	methods := resp.Header.Get("Access-Control-Allow-Methods")
+	assert.Contains(t, methods, "GET")
+	assert.Contains(t, methods, "PATCH")
+	assert.NotContains(t, methods, "DELETE")
+}
+
+func TestCORS_CustomHeaders(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {})
+
+	req := httptest.NewRequest("OPTIONS", "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	req.Header.Set("Access-Control-Request-Method", "POST")
+	w := httptest.NewRecorder()
+
+	CORS(CorsAllowedHeaders("X-Custom-Header", "X-Another"))(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	headers := resp.Header.Get("Access-Control-Allow-Headers")
+	assert.Contains(t, headers, "X-Custom-Header")
+	assert.Contains(t, headers, "X-Another")
+}
+
+func TestCORS_ExposedHeaders(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	CORS(CorsExposedHeaders("X-Request-Id", "X-Total-Count"))(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	exposed := resp.Header.Get("Access-Control-Expose-Headers")
+	assert.Contains(t, exposed, "X-Request-Id")
+	assert.Contains(t, exposed, "X-Total-Count")
+}
+
+func TestCORS_VaryHeader(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	CORS()(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Contains(t, resp.Header.Get("Vary"), "Origin")
+}
+
+func TestCORS_OptionsWithoutPreflight(t *testing.T) {
+	handlerCalled := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// OPTIONS without Access-Control-Request-Method is not a preflight
+	req := httptest.NewRequest("OPTIONS", "/test", http.NoBody)
+	req.Header.Set("Origin", "https://example.com")
+	w := httptest.NewRecorder()
+
+	CORS()(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.True(t, handlerCalled, "handler should be called for non-preflight OPTIONS")
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+}
+
+func TestCORS_Integration(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"status":"ok"}`))
+	})
+
+	ts := httptest.NewServer(CORS(
+		CorsAllowedOrigins("https://app.example.com"),
+		CorsAllowCredentials(true),
+		CorsMaxAge(86400),
+		CorsExposedHeaders("X-Request-Id"),
+	)(handler))
+	defer ts.Close()
+
+	client := &http.Client{}
+
+	t.Run("preflight request", func(t *testing.T) {
+		req, err := http.NewRequest("OPTIONS", ts.URL+"/api", http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://app.example.com")
+		req.Header.Set("Access-Control-Request-Method", "POST")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusNoContent, resp.StatusCode)
+		assert.Equal(t, "https://app.example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Equal(t, "true", resp.Header.Get("Access-Control-Allow-Credentials"))
+		assert.Equal(t, "86400", resp.Header.Get("Access-Control-Max-Age"))
+	})
+
+	t.Run("actual request", func(t *testing.T) {
+		req, err := http.NewRequest("GET", ts.URL+"/api", http.NoBody)
+		require.NoError(t, err)
+		req.Header.Set("Origin", "https://app.example.com")
+
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+		assert.Equal(t, "https://app.example.com", resp.Header.Get("Access-Control-Allow-Origin"))
+		assert.Contains(t, resp.Header.Get("Access-Control-Expose-Headers"), "X-Request-Id")
+	})
+}

--- a/csrf.go
+++ b/csrf.go
@@ -1,0 +1,207 @@
+//go:build !go1.25
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+// CrossOriginProtection provides CSRF protection using modern browser Fetch metadata.
+// It validates requests using Sec-Fetch-Site and Origin headers, rejecting cross-origin
+// state-changing requests. Safe methods (GET, HEAD, OPTIONS) are always allowed.
+//
+// For Go 1.25+, this wraps the stdlib http.CrossOriginProtection.
+// For earlier versions, it provides an equivalent custom implementation.
+type CrossOriginProtection struct {
+	mu             sync.RWMutex
+	trustedOrigins map[string]bool
+	bypassPatterns []string
+	denyHandler    http.Handler
+}
+
+// NewCrossOriginProtection creates a new CSRF protection middleware.
+func NewCrossOriginProtection() *CrossOriginProtection {
+	return &CrossOriginProtection{
+		trustedOrigins: make(map[string]bool),
+	}
+}
+
+// AddTrustedOrigin adds an origin that should be allowed to make cross-origin requests.
+// The origin must be in the format "scheme://host" or "scheme://host:port".
+// Returns an error if the origin format is invalid.
+func (c *CrossOriginProtection) AddTrustedOrigin(origin string) error {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return fmt.Errorf("invalid origin: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("origin must have scheme and host: %s", origin)
+	}
+	if u.Path != "" && u.Path != "/" {
+		return fmt.Errorf("origin must not have path: %s", origin)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("origin must not have query or fragment: %s", origin)
+	}
+
+	normalized := strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host)
+
+	c.mu.Lock()
+	c.trustedOrigins[normalized] = true
+	c.mu.Unlock()
+	return nil
+}
+
+// AddBypassPattern adds a URL pattern that should bypass CSRF protection.
+// Patterns follow the same syntax as http.ServeMux (e.g., "/api/webhook", "/oauth/").
+// Use sparingly and only for endpoints that have alternative authentication.
+func (c *CrossOriginProtection) AddBypassPattern(pattern string) {
+	c.mu.Lock()
+	c.bypassPatterns = append(c.bypassPatterns, pattern)
+	c.mu.Unlock()
+}
+
+// SetDenyHandler sets a custom handler for rejected requests.
+// If not set, rejected requests receive a 403 Forbidden response.
+func (c *CrossOriginProtection) SetDenyHandler(h http.Handler) {
+	c.mu.Lock()
+	c.denyHandler = h
+	c.mu.Unlock()
+}
+
+// Check validates a request against CSRF protection rules.
+// Returns nil if the request is allowed, or an error describing why it was rejected.
+func (c *CrossOriginProtection) Check(r *http.Request) error {
+	// safe methods are always allowed
+	if isSafeMethod(r.Method) {
+		return nil
+	}
+
+	// check bypass patterns
+	if c.matchesBypassPattern(r.URL.Path) {
+		return nil
+	}
+
+	// check Sec-Fetch-Site header (modern browsers)
+	secFetchSite := r.Header.Get("Sec-Fetch-Site")
+	if secFetchSite != "" {
+		switch secFetchSite {
+		case "same-origin", "none":
+			return nil
+		case "cross-site", "same-site":
+			// check if origin is trusted
+			origin := r.Header.Get("Origin")
+			if origin != "" && c.isOriginTrusted(origin) {
+				return nil
+			}
+			return fmt.Errorf("cross-origin request blocked: Sec-Fetch-Site=%s", secFetchSite)
+		}
+	}
+
+	// fallback: check Origin header against Host
+	origin := r.Header.Get("Origin")
+	if origin != "" {
+		// check if origin is trusted
+		if c.isOriginTrusted(origin) {
+			return nil
+		}
+
+		// compare origin host with request host
+		originURL, err := url.Parse(origin)
+		if err != nil {
+			return fmt.Errorf("invalid Origin header: %w", err)
+		}
+
+		requestHost := r.Host
+		if requestHost == "" {
+			requestHost = r.URL.Host
+		}
+
+		// normalize hosts for comparison
+		originHost := strings.ToLower(originURL.Host)
+		requestHost = strings.ToLower(requestHost)
+
+		if originHost != requestHost {
+			return fmt.Errorf("cross-origin request blocked: origin %s does not match host %s", originHost, requestHost)
+		}
+		return nil
+	}
+
+	// no Sec-Fetch-Site or Origin headers - assume same-origin or non-browser request
+	return nil
+}
+
+// Handler wraps an http.Handler with CSRF protection.
+// Rejected requests receive a 403 Forbidden response (or custom deny handler).
+func (c *CrossOriginProtection) Handler(h http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := c.Check(r); err != nil {
+			c.mu.RLock()
+			deny := c.denyHandler
+			c.mu.RUnlock()
+
+			if deny != nil {
+				deny.ServeHTTP(w, r)
+				return
+			}
+			http.Error(w, "Forbidden - CSRF check failed", http.StatusForbidden)
+			return
+		}
+		h.ServeHTTP(w, r)
+	})
+}
+
+// isSafeMethod returns true for HTTP methods that don't modify state.
+func isSafeMethod(method string) bool {
+	switch method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return true
+	}
+	return false
+}
+
+// isOriginTrusted checks if the origin is in the trusted list.
+func (c *CrossOriginProtection) isOriginTrusted(origin string) bool {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return false
+	}
+	normalized := strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host)
+
+	c.mu.RLock()
+	trusted := c.trustedOrigins[normalized]
+	c.mu.RUnlock()
+	return trusted
+}
+
+// matchesBypassPattern checks if the path matches any bypass pattern.
+func (c *CrossOriginProtection) matchesBypassPattern(path string) bool {
+	c.mu.RLock()
+	patterns := make([]string, len(c.bypassPatterns))
+	copy(patterns, c.bypassPatterns)
+	c.mu.RUnlock()
+
+	for _, pattern := range patterns {
+		if matchPattern(pattern, path) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchPattern implements simple pattern matching similar to http.ServeMux.
+func matchPattern(pattern, path string) bool {
+	// exact match
+	if pattern == path {
+		return true
+	}
+	// prefix match for patterns ending with /
+	if strings.HasSuffix(pattern, "/") && strings.HasPrefix(path, pattern) {
+		return true
+	}
+	return false
+}

--- a/csrf_go125.go
+++ b/csrf_go125.go
@@ -1,0 +1,111 @@
+//go:build go1.25
+
+package rest
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+// CrossOriginProtection provides CSRF protection using modern browser Fetch metadata.
+// It validates requests using Sec-Fetch-Site and Origin headers, rejecting cross-origin
+// state-changing requests. Safe methods (GET, HEAD, OPTIONS) are always allowed.
+//
+// For Go 1.25+, this wraps the stdlib http.CrossOriginProtection.
+// For earlier versions, it provides an equivalent custom implementation.
+type CrossOriginProtection struct {
+	stdlib *http.CrossOriginProtection
+}
+
+// NewCrossOriginProtection creates a new CSRF protection middleware.
+func NewCrossOriginProtection() *CrossOriginProtection {
+	return &CrossOriginProtection{
+		stdlib: http.NewCrossOriginProtection(),
+	}
+}
+
+// AddTrustedOrigin adds an origin that should be allowed to make cross-origin requests.
+// The origin must be in the format "scheme://host" or "scheme://host:port".
+// Returns an error if the origin format is invalid.
+func (c *CrossOriginProtection) AddTrustedOrigin(origin string) error {
+	u, err := url.Parse(origin)
+	if err != nil {
+		return fmt.Errorf("invalid origin: %w", err)
+	}
+	if u.Scheme == "" || u.Host == "" {
+		return fmt.Errorf("origin must have scheme and host: %s", origin)
+	}
+	if u.Path != "" && u.Path != "/" {
+		return fmt.Errorf("origin must not have path: %s", origin)
+	}
+	if u.RawQuery != "" || u.Fragment != "" {
+		return fmt.Errorf("origin must not have query or fragment: %s", origin)
+	}
+
+	// normalize to lowercase for consistent case-insensitive matching
+	normalized := strings.ToLower(u.Scheme) + "://" + strings.ToLower(u.Host)
+	return c.stdlib.AddTrustedOrigin(normalized)
+}
+
+// AddBypassPattern adds a URL pattern that should bypass CSRF protection.
+// Patterns follow the same syntax as http.ServeMux (e.g., "/api/webhook", "/oauth/").
+// Use sparingly and only for endpoints that have alternative authentication.
+func (c *CrossOriginProtection) AddBypassPattern(pattern string) {
+	c.stdlib.AddInsecureBypassPattern(pattern)
+}
+
+// SetDenyHandler sets a custom handler for rejected requests.
+// If not set, rejected requests receive a 403 Forbidden response.
+func (c *CrossOriginProtection) SetDenyHandler(h http.Handler) {
+	c.stdlib.SetDenyHandler(h)
+}
+
+// Check validates a request against CSRF protection rules.
+// Returns nil if the request is allowed, or an error describing why it was rejected.
+func (c *CrossOriginProtection) Check(r *http.Request) error {
+	// the stdlib Check method panics or returns void, so we use our own check logic
+	// by creating a test handler and seeing if it gets called
+
+	// safe methods are always allowed
+	switch r.Method {
+	case http.MethodGet, http.MethodHead, http.MethodOptions:
+		return nil
+	}
+
+	// use a test to determine if request would be allowed
+	allowed := false
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		allowed = true
+	})
+
+	// create a response recorder to capture the result
+	rec := &discardResponseWriter{}
+	c.stdlib.Handler(testHandler).ServeHTTP(rec, r)
+
+	if !allowed {
+		return fmt.Errorf("cross-origin request blocked by CSRF protection")
+	}
+	return nil
+}
+
+// Handler wraps an http.Handler with CSRF protection.
+// Rejected requests receive a 403 Forbidden response (or custom deny handler).
+func (c *CrossOriginProtection) Handler(h http.Handler) http.Handler {
+	return c.stdlib.Handler(h)
+}
+
+// discardResponseWriter is a minimal ResponseWriter for testing.
+type discardResponseWriter struct {
+	header http.Header
+}
+
+func (d *discardResponseWriter) Header() http.Header {
+	if d.header == nil {
+		d.header = make(http.Header)
+	}
+	return d.header
+}
+func (d *discardResponseWriter) Write(b []byte) (int, error) { return len(b), nil }
+func (d *discardResponseWriter) WriteHeader(_ int)           {}

--- a/csrf_test.go
+++ b/csrf_test.go
@@ -1,0 +1,324 @@
+package rest
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCSRF_SafeMethods(t *testing.T) {
+	protection := NewCrossOriginProtection()
+
+	tests := []struct {
+		method string
+	}{
+		{http.MethodGet},
+		{http.MethodHead},
+		{http.MethodOptions},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/api/data", http.NoBody)
+			req.Header.Set("Origin", "https://evil.com")
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+
+			err := protection.Check(req)
+			assert.NoError(t, err, "safe methods should always pass")
+		})
+	}
+}
+
+func TestCSRF_UnsafeMethodsBlocked(t *testing.T) {
+	protection := NewCrossOriginProtection()
+
+	tests := []struct {
+		method string
+	}{
+		{http.MethodPost},
+		{http.MethodPut},
+		{http.MethodDelete},
+		{http.MethodPatch},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.method, func(t *testing.T) {
+			req := httptest.NewRequest(tt.method, "/api/data", http.NoBody)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+
+			err := protection.Check(req)
+			assert.Error(t, err, "cross-site unsafe methods should be blocked")
+		})
+	}
+}
+
+func TestCSRF_SecFetchSite(t *testing.T) {
+	protection := NewCrossOriginProtection()
+
+	tests := []struct {
+		name         string
+		secFetchSite string
+		shouldAllow  bool
+	}{
+		{name: "same-origin allowed", secFetchSite: "same-origin", shouldAllow: true},
+		{name: "none allowed", secFetchSite: "none", shouldAllow: true},
+		{name: "cross-site blocked", secFetchSite: "cross-site", shouldAllow: false},
+		{name: "same-site blocked", secFetchSite: "same-site", shouldAllow: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, "/api/data", http.NoBody)
+			req.Header.Set("Sec-Fetch-Site", tt.secFetchSite)
+
+			err := protection.Check(req)
+			if tt.shouldAllow {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestCSRF_NoHeaders(t *testing.T) {
+	protection := NewCrossOriginProtection()
+
+	// request without Sec-Fetch-Site or Origin headers
+	// should be allowed (assumed same-origin or non-browser)
+	req := httptest.NewRequest(http.MethodPost, "/api/data", http.NoBody)
+
+	err := protection.Check(req)
+	assert.NoError(t, err, "requests without CSRF headers should be allowed")
+}
+
+func TestCSRF_OriginMatchesHost(t *testing.T) {
+	protection := NewCrossOriginProtection()
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/api/data", http.NoBody)
+	req.Host = "example.com"
+	req.Header.Set("Origin", "https://example.com")
+
+	err := protection.Check(req)
+	assert.NoError(t, err, "origin matching host should be allowed")
+}
+
+func TestCSRF_OriginMismatchHost(t *testing.T) {
+	protection := NewCrossOriginProtection()
+
+	req := httptest.NewRequest(http.MethodPost, "https://example.com/api/data", http.NoBody)
+	req.Host = "example.com"
+	req.Header.Set("Origin", "https://evil.com")
+
+	err := protection.Check(req)
+	assert.Error(t, err, "origin not matching host should be blocked")
+}
+
+func TestCSRF_TrustedOrigin(t *testing.T) {
+	protection := NewCrossOriginProtection()
+	err := protection.AddTrustedOrigin("https://trusted.com")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/data", http.NoBody)
+	req.Host = "example.com"
+	req.Header.Set("Origin", "https://trusted.com")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+
+	err = protection.Check(req)
+	assert.NoError(t, err, "trusted origin should be allowed")
+}
+
+func TestCSRF_TrustedOriginCaseInsensitive(t *testing.T) {
+	protection := NewCrossOriginProtection()
+	err := protection.AddTrustedOrigin("https://TRUSTED.COM")
+	require.NoError(t, err)
+
+	req := httptest.NewRequest(http.MethodPost, "/api/data", http.NoBody)
+	req.Header.Set("Origin", "https://trusted.com")
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+
+	err = protection.Check(req)
+	assert.NoError(t, err, "origin matching should be case-insensitive")
+}
+
+func TestCSRF_AddTrustedOriginValidation(t *testing.T) {
+	tests := []struct {
+		name      string
+		origin    string
+		wantError bool
+	}{
+		{name: "valid https", origin: "https://example.com", wantError: false},
+		{name: "valid http", origin: "http://example.com", wantError: false},
+		{name: "valid with port", origin: "https://example.com:8443", wantError: false},
+		{name: "missing scheme", origin: "example.com", wantError: true},
+		{name: "has path", origin: "https://example.com/path", wantError: true},
+		{name: "has query", origin: "https://example.com?foo=bar", wantError: true},
+		{name: "has fragment", origin: "https://example.com#section", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := NewCrossOriginProtection()
+			err := p.AddTrustedOrigin(tt.origin)
+			if tt.wantError {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestCSRF_BypassPattern(t *testing.T) {
+	protection := NewCrossOriginProtection()
+	protection.AddBypassPattern("/webhook")
+	protection.AddBypassPattern("/oauth/")
+
+	tests := []struct {
+		name        string
+		path        string
+		shouldAllow bool
+	}{
+		{name: "exact match", path: "/webhook", shouldAllow: true},
+		{name: "prefix match", path: "/oauth/callback", shouldAllow: true},
+		{name: "no match", path: "/api/data", shouldAllow: false},
+		{name: "partial no match", path: "/webhooks", shouldAllow: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodPost, tt.path, http.NoBody)
+			req.Header.Set("Sec-Fetch-Site", "cross-site")
+
+			err := protection.Check(req)
+			if tt.shouldAllow {
+				assert.NoError(t, err)
+			} else {
+				assert.Error(t, err)
+			}
+		})
+	}
+}
+
+func TestCSRF_Handler(t *testing.T) {
+	protection := NewCrossOriginProtection()
+
+	handlerCalled := false
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		handlerCalled = true
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("allowed request", func(t *testing.T) {
+		handlerCalled = false
+		req := httptest.NewRequest(http.MethodPost, "/api/data", http.NoBody)
+		req.Header.Set("Sec-Fetch-Site", "same-origin")
+		w := httptest.NewRecorder()
+
+		protection.Handler(handler).ServeHTTP(w, req)
+
+		assert.True(t, handlerCalled, "handler should be called for allowed requests")
+		assert.Equal(t, http.StatusOK, w.Code)
+	})
+
+	t.Run("blocked request", func(t *testing.T) {
+		handlerCalled = false
+		req := httptest.NewRequest(http.MethodPost, "/api/data", http.NoBody)
+		req.Header.Set("Sec-Fetch-Site", "cross-site")
+		w := httptest.NewRecorder()
+
+		protection.Handler(handler).ServeHTTP(w, req)
+
+		assert.False(t, handlerCalled, "handler should not be called for blocked requests")
+		assert.Equal(t, http.StatusForbidden, w.Code)
+	})
+}
+
+func TestCSRF_CustomDenyHandler(t *testing.T) {
+	protection := NewCrossOriginProtection()
+
+	customDenyCalled := false
+	protection.SetDenyHandler(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		customDenyCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	}))
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest(http.MethodPost, "/api/data", http.NoBody)
+	req.Header.Set("Sec-Fetch-Site", "cross-site")
+	w := httptest.NewRecorder()
+
+	protection.Handler(handler).ServeHTTP(w, req)
+
+	assert.True(t, customDenyCalled, "custom deny handler should be called")
+	assert.Equal(t, http.StatusTeapot, w.Code)
+}
+
+func TestCSRF_Integration(t *testing.T) {
+	protection := NewCrossOriginProtection()
+	err := protection.AddTrustedOrigin("https://mobile.example.com")
+	require.NoError(t, err)
+	protection.AddBypassPattern("/api/webhook")
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("OK"))
+	})
+
+	ts := httptest.NewServer(protection.Handler(handler))
+	defer ts.Close()
+
+	client := &http.Client{}
+
+	t.Run("GET always allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodGet, ts.URL+"/api/data", http.NoBody)
+		req.Header.Set("Sec-Fetch-Site", "cross-site")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("POST same-origin allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/data", http.NoBody)
+		req.Header.Set("Sec-Fetch-Site", "same-origin")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("POST cross-site blocked", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/data", http.NoBody)
+		req.Header.Set("Sec-Fetch-Site", "cross-site")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusForbidden, resp.StatusCode)
+	})
+
+	t.Run("POST trusted origin allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/data", http.NoBody)
+		req.Header.Set("Sec-Fetch-Site", "cross-site")
+		req.Header.Set("Origin", "https://mobile.example.com")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+
+	t.Run("POST bypass pattern allowed", func(t *testing.T) {
+		req, _ := http.NewRequest(http.MethodPost, ts.URL+"/api/webhook", http.NoBody)
+		req.Header.Set("Sec-Fetch-Site", "cross-site")
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		assert.Equal(t, http.StatusOK, resp.StatusCode)
+	})
+}

--- a/rewrite.go
+++ b/rewrite.go
@@ -9,6 +9,79 @@ import (
 	"strings"
 )
 
+// CleanPath middleware cleans double slashes from URL path.
+// For example, if a request is made to /users//1 or //users////1,
+// it will be cleaned to /users/1 before routing.
+// Trailing slashes are preserved: /users//1/ becomes /users/1/.
+// Dot segments (. and ..) are intentionally NOT cleaned to preserve routing semantics.
+func CleanPath(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rctx := r.Context()
+		// skip if already cleaned
+		if _, ok := rctx.Value(contextKey("cleanpath")).(bool); ok {
+			next.ServeHTTP(w, r)
+			return
+		}
+
+		p := r.URL.Path
+		cleaned := cleanDoubleSlashes(p)
+
+		if cleaned != p {
+			r.URL.Path = cleaned
+			if r.URL.RawPath != "" {
+				// clean double slashes in RawPath separately to preserve percent-encoding
+				r.URL.RawPath = cleanDoubleSlashes(r.URL.RawPath)
+			}
+			rctx = context.WithValue(rctx, contextKey("cleanpath"), true)
+			r = r.WithContext(rctx)
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// cleanDoubleSlashes removes consecutive slashes from path while preserving
+// trailing slashes and dot segments (. and ..).
+func cleanDoubleSlashes(p string) string {
+	if p == "" || p == "/" {
+		return p
+	}
+
+	var b strings.Builder
+	b.Grow(len(p))
+
+	prevSlash := false
+	for i := 0; i < len(p); i++ {
+		c := p[i]
+		if c == '/' {
+			if !prevSlash {
+				b.WriteByte(c)
+			}
+			prevSlash = true
+		} else {
+			b.WriteByte(c)
+			prevSlash = false
+		}
+	}
+
+	return b.String()
+}
+
+// StripSlashes middleware removes trailing slashes from URL path.
+// For example, /users/1/ becomes /users/1.
+// The root path "/" is preserved.
+func StripSlashes(next http.Handler) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		p := r.URL.Path
+		if len(p) > 1 && p[len(p)-1] == '/' {
+			r.URL.Path = p[:len(p)-1]
+			if r.URL.RawPath != "" {
+				r.URL.RawPath = strings.TrimSuffix(r.URL.RawPath, "/")
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
 // Rewrite middleware with from->to rule. Supports regex (like nginx) and prevents multiple rewrites
 // example: Rewrite(`^/sites/(.*)/settings/$`, `/sites/settings/$1`
 func Rewrite(from, to string) func(http.Handler) http.Handler {

--- a/rewrite_test.go
+++ b/rewrite_test.go
@@ -101,3 +101,203 @@ func TestRewrite_DoubleRewritePrevention(t *testing.T) {
 	// only first rewrite should be applied
 	assert.Equal(t, 1, rewriteCount, "only one rewrite should be applied")
 }
+
+func TestCleanPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "no change needed", input: "/users/1", expected: "/users/1"},
+		{name: "double slash", input: "/users//1", expected: "/users/1"},
+		{name: "multiple double slashes", input: "//users////1", expected: "/users/1"},
+		{name: "trailing double slash", input: "/users//", expected: "/users/"},
+		{name: "root path", input: "/", expected: "/"},
+		{name: "mixed", input: "//api//v1//users", expected: "/api/v1/users"},
+		{name: "single trailing slash preserved", input: "/users/", expected: "/users/"},
+		{name: "double slash with trailing preserved", input: "/api//v1/", expected: "/api/v1/"},
+		{name: "dot segments preserved", input: "/api/../admin", expected: "/api/../admin"},
+		{name: "dot segments with double slash", input: "/api//../admin", expected: "/api/../admin"},
+		{name: "single dot preserved", input: "/api/./v1", expected: "/api/./v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resultPath string
+			testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				resultPath = r.URL.Path
+			})
+
+			req := httptest.NewRequest("GET", tt.input, http.NoBody)
+			rr := httptest.NewRecorder()
+			CleanPath(testHandler).ServeHTTP(rr, req)
+			assert.Equal(t, tt.expected, resultPath)
+		})
+	}
+}
+
+func TestCleanPath_EmptyPath(t *testing.T) {
+	var resultPath string
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		resultPath = r.URL.Path
+	})
+
+	req := httptest.NewRequest("GET", "/", http.NoBody)
+	req.URL.Path = "" // manually set empty path
+	rr := httptest.NewRecorder()
+	CleanPath(testHandler).ServeHTTP(rr, req)
+	assert.Empty(t, resultPath, "empty path should remain empty")
+}
+
+func TestCleanPath_DoubleCleanPrevention(t *testing.T) {
+	cleanCount := 0
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/users/1", r.URL.Path)
+	})
+
+	countingClean := func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			cleanCount++
+			CleanPath(next).ServeHTTP(w, r)
+		})
+	}
+
+	req := httptest.NewRequest("GET", "/users//1", http.NoBody)
+	rr := httptest.NewRecorder()
+	// chain two CleanPath calls
+	countingClean(countingClean(testHandler)).ServeHTTP(rr, req)
+	// path.Clean is called but context flag prevents redundant processing
+	assert.Equal(t, 2, cleanCount, "middleware called twice")
+}
+
+func TestStripSlashes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "trailing slash removed", input: "/users/", expected: "/users"},
+		{name: "no trailing slash", input: "/users", expected: "/users"},
+		{name: "root preserved", input: "/", expected: "/"},
+		{name: "deep path", input: "/api/v1/users/", expected: "/api/v1/users"},
+		{name: "multiple segments", input: "/a/b/c/d/", expected: "/a/b/c/d"},
+		{name: "multiple trailing slashes", input: "/users//", expected: "/users/"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resultPath string
+			testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				resultPath = r.URL.Path
+			})
+
+			req := httptest.NewRequest("GET", tt.input, http.NoBody)
+			rr := httptest.NewRecorder()
+			StripSlashes(testHandler).ServeHTTP(rr, req)
+			assert.Equal(t, tt.expected, resultPath)
+		})
+	}
+}
+
+func TestStripSlashes_WithRawPath(t *testing.T) {
+	var resultRawPath string
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		resultRawPath = r.URL.RawPath
+	})
+
+	req := httptest.NewRequest("GET", "/users/1/", http.NoBody)
+	req.URL.RawPath = "/users%2F1/" // encoded slash in segment
+	rr := httptest.NewRecorder()
+	StripSlashes(testHandler).ServeHTTP(rr, req)
+	// RawPath trailing slash should also be stripped
+	assert.Equal(t, "/users%2F1", resultRawPath)
+}
+
+func TestCleanPath_WithRawPath(t *testing.T) {
+	t.Run("rawpath only set when originally present", func(t *testing.T) {
+		var resultRawPath string
+		testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			resultRawPath = r.URL.RawPath
+		})
+
+		// request without RawPath - should NOT set RawPath after cleaning
+		req := httptest.NewRequest("GET", "/users//1", http.NoBody)
+		req.URL.RawPath = "" // explicitly empty
+		rr := httptest.NewRecorder()
+		CleanPath(testHandler).ServeHTTP(rr, req)
+		assert.Empty(t, resultRawPath, "RawPath should remain empty when not originally set")
+	})
+
+	t.Run("rawpath with literal double slashes cleaned", func(t *testing.T) {
+		var resultRawPath string
+		testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			resultRawPath = r.URL.RawPath
+		})
+
+		req := httptest.NewRequest("GET", "/users//1", http.NoBody)
+		req.URL.RawPath = "/users//1" // literal double slash in RawPath
+		rr := httptest.NewRecorder()
+		CleanPath(testHandler).ServeHTTP(rr, req)
+		assert.Equal(t, "/users/1", resultRawPath, "literal double slashes in RawPath should be cleaned")
+	})
+
+	t.Run("rawpath encoding preserved", func(t *testing.T) {
+		var resultRawPath string
+		testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			resultRawPath = r.URL.RawPath
+		})
+
+		req := httptest.NewRequest("GET", "/files//tmp", http.NoBody)
+		req.URL.RawPath = "/files//tmp%2Flog%20file" // literal // but encoded %2F and %20
+		rr := httptest.NewRecorder()
+		CleanPath(testHandler).ServeHTTP(rr, req)
+		// literal // cleaned, but %2F and %20 preserved
+		assert.Equal(t, "/files/tmp%2Flog%20file", resultRawPath, "percent-encoding should be preserved")
+	})
+}
+
+func TestCleanPath_ChainedWithStripSlashes(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{name: "double slash with trailing", input: "/api//v1/", expected: "/api/v1"},
+		{name: "multiple double slashes with trailing", input: "//api////v1//", expected: "/api/v1"},
+		{name: "only double slashes", input: "//", expected: "/"},
+		{name: "clean path only", input: "/api//v1", expected: "/api/v1"},
+		{name: "strip only", input: "/api/v1/", expected: "/api/v1"},
+		{name: "no changes needed", input: "/api/v1", expected: "/api/v1"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var resultPath string
+			testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+				resultPath = r.URL.Path
+			})
+
+			req := httptest.NewRequest("GET", tt.input, http.NoBody)
+			rr := httptest.NewRecorder()
+			// chain: CleanPath first, then StripSlashes
+			CleanPath(StripSlashes(testHandler)).ServeHTTP(rr, req)
+			assert.Equal(t, tt.expected, resultPath)
+		})
+	}
+}
+
+func TestCleanPath_EncodedSlashes(t *testing.T) {
+	// this test verifies that cleanDoubleSlashes operates on Path, not RawPath
+	// URL-encoded slashes (%2F) in RawPath don't become // in Path
+	var resultPath string
+	testHandler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		resultPath = r.URL.Path
+	})
+
+	req := httptest.NewRequest("GET", "/api/v1/file", http.NoBody)
+	req.URL.Path = "/api/v1/file"
+	req.URL.RawPath = "/api/v1/file%2Fname" // %2F is encoded /
+	rr := httptest.NewRecorder()
+	CleanPath(testHandler).ServeHTTP(rr, req)
+	assert.Equal(t, "/api/v1/file", resultPath, "Path should not be affected by encoded chars in RawPath")
+}

--- a/secure.go
+++ b/secure.go
@@ -1,0 +1,207 @@
+package rest
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// SecureConfig defines security headers configuration.
+// Use SecOpt functions to customize.
+type SecureConfig struct {
+	// xFrameOptions sets X-Frame-Options header. Default: DENY
+	XFrameOptions string
+	// xContentTypeOptions sets X-Content-Type-Options. Default: nosniff
+	XContentTypeOptions string
+	// ReferrerPolicy sets Referrer-Policy header. Default: strict-origin-when-cross-origin
+	ReferrerPolicy string
+	// ContentSecurityPolicy sets Content-Security-Policy header. Default: empty (not set)
+	ContentSecurityPolicy string
+	// PermissionsPolicy sets Permissions-Policy header. Default: empty (not set)
+	PermissionsPolicy string
+	// sTSSeconds sets max-age for Strict-Transport-Security. 0 disables.
+	// only sent when request uses HTTPS. Default: 31536000 (1 year)
+	STSSeconds int
+	// sTSIncludeSubdomains adds includeSubDomains to HSTS. Default: true
+	STSIncludeSubdomains bool
+	// sTSPreload adds preload flag to HSTS. Default: false
+	STSPreload bool
+	// xSSProtection sets X-XSS-Protection header. Default: 1; mode=block
+	// note: this header is deprecated in modern browsers but still useful for older ones
+	XSSProtection string
+}
+
+// SecOpt is a functional option for SecureConfig
+type SecOpt func(*SecureConfig)
+
+// defaultSecureConfig returns config with sensible defaults
+func defaultSecureConfig() SecureConfig {
+	return SecureConfig{
+		XFrameOptions:        "DENY",
+		XContentTypeOptions:  "nosniff",
+		ReferrerPolicy:       "strict-origin-when-cross-origin",
+		STSSeconds:           31536000, // 1 year
+		STSIncludeSubdomains: true,
+		STSPreload:           false,
+		XSSProtection:        "1; mode=block",
+	}
+}
+
+// SecFrameOptions sets X-Frame-Options header.
+// Common values: "DENY", "SAMEORIGIN"
+func SecFrameOptions(value string) SecOpt {
+	return func(c *SecureConfig) {
+		c.XFrameOptions = value
+	}
+}
+
+// SecContentTypeNosniff enables or disables X-Content-Type-Options: nosniff
+func SecContentTypeNosniff(enable bool) SecOpt {
+	return func(c *SecureConfig) {
+		if enable {
+			c.XContentTypeOptions = "nosniff"
+		} else {
+			c.XContentTypeOptions = ""
+		}
+	}
+}
+
+// SecReferrerPolicy sets Referrer-Policy header.
+// Common values: "no-referrer", "same-origin", "strict-origin", "strict-origin-when-cross-origin"
+func SecReferrerPolicy(policy string) SecOpt {
+	return func(c *SecureConfig) {
+		c.ReferrerPolicy = policy
+	}
+}
+
+// SecContentSecurityPolicy sets Content-Security-Policy header.
+// Example: "default-src 'self'; script-src 'self'"
+func SecContentSecurityPolicy(policy string) SecOpt {
+	return func(c *SecureConfig) {
+		c.ContentSecurityPolicy = policy
+	}
+}
+
+// SecPermissionsPolicy sets Permissions-Policy header.
+// Example: "geolocation=(), microphone=()"
+func SecPermissionsPolicy(policy string) SecOpt {
+	return func(c *SecureConfig) {
+		c.PermissionsPolicy = policy
+	}
+}
+
+// SecHSTS configures Strict-Transport-Security header.
+// maxAge is in seconds (0 disables HSTS), includeSubdomains and preload are optional flags.
+// Note: HSTS header is only sent when the request is over HTTPS.
+func SecHSTS(maxAge int, includeSubdomains, preload bool) SecOpt {
+	return func(c *SecureConfig) {
+		c.STSSeconds = maxAge
+		c.STSIncludeSubdomains = includeSubdomains
+		c.STSPreload = preload
+	}
+}
+
+// SecXSSProtection sets X-XSS-Protection header.
+// Set to empty string to disable. Common values: "0", "1", "1; mode=block"
+func SecXSSProtection(value string) SecOpt {
+	return func(c *SecureConfig) {
+		c.XSSProtection = value
+	}
+}
+
+// SecAllHeaders is a convenience option to set common headers for secure web applications.
+// Sets CSP with self-only policy and restrictive permissions.
+func SecAllHeaders() SecOpt {
+	return func(c *SecureConfig) {
+		c.ContentSecurityPolicy = "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; form-action 'self'; frame-ancestors 'none'"
+		c.PermissionsPolicy = "geolocation=(), microphone=(), camera=()"
+	}
+}
+
+// Secure is middleware that adds security headers to responses.
+// By default it sets: X-Frame-Options, X-Content-Type-Options, Referrer-Policy,
+// X-XSS-Protection, and Strict-Transport-Security (for HTTPS only).
+// Use SecOpt functions to customize the configuration.
+func Secure(opts ...SecOpt) func(http.Handler) http.Handler {
+	cfg := defaultSecureConfig()
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// set security headers
+			if cfg.XFrameOptions != "" {
+				w.Header().Set("X-Frame-Options", cfg.XFrameOptions)
+			}
+			if cfg.XContentTypeOptions != "" {
+				w.Header().Set("X-Content-Type-Options", cfg.XContentTypeOptions)
+			}
+			if cfg.ReferrerPolicy != "" {
+				w.Header().Set("Referrer-Policy", cfg.ReferrerPolicy)
+			}
+			if cfg.XSSProtection != "" {
+				w.Header().Set("X-XSS-Protection", cfg.XSSProtection)
+			}
+			if cfg.ContentSecurityPolicy != "" {
+				w.Header().Set("Content-Security-Policy", cfg.ContentSecurityPolicy)
+			}
+			if cfg.PermissionsPolicy != "" {
+				w.Header().Set("Permissions-Policy", cfg.PermissionsPolicy)
+			}
+
+			// HSTS only for HTTPS connections
+			if cfg.STSSeconds > 0 && isHTTPS(r) {
+				sts := "max-age=" + strconv.Itoa(cfg.STSSeconds)
+				if cfg.STSIncludeSubdomains {
+					sts += "; includeSubDomains"
+				}
+				if cfg.STSPreload {
+					sts += "; preload"
+				}
+				w.Header().Set("Strict-Transport-Security", sts)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}
+
+// isHTTPS checks if the request is over HTTPS by examining TLS state and common proxy headers
+func isHTTPS(r *http.Request) bool {
+	// direct TLS connection
+	if r.TLS != nil {
+		return true
+	}
+	// check common proxy headers (case-insensitive)
+	if strings.EqualFold(r.Header.Get("X-Forwarded-Proto"), "https") {
+		return true
+	}
+	// check RFC 7239 Forwarded header
+	if forwarded := r.Header.Get("Forwarded"); forwarded != "" {
+		if forwardedProtoIsHTTPS(forwarded) {
+			return true
+		}
+	}
+	return false
+}
+
+// forwardedProtoIsHTTPS parses RFC 7239 Forwarded header to check for proto=https.
+// The header format is: Forwarded: for=1.2.3.4;proto=https;by=proxy, for=5.6.7.8
+// Parameters are separated by semicolons, multiple forwarded elements by commas.
+func forwardedProtoIsHTTPS(header string) bool {
+	// split by comma to get individual forwarded elements
+	for element := range strings.SplitSeq(header, ",") {
+		// split by semicolon to get parameters within element
+		for param := range strings.SplitSeq(element, ";") {
+			param = strings.TrimSpace(param)
+			// check for proto=https (case-insensitive per RFC 7239)
+			if len(param) > 6 && strings.EqualFold(param[:6], "proto=") {
+				if strings.EqualFold(strings.TrimSpace(param[6:]), "https") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}

--- a/secure_test.go
+++ b/secure_test.go
@@ -1,0 +1,303 @@
+package rest
+
+import (
+	"crypto/tls"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSecure_Defaults(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	ts := httptest.NewServer(Secure()(handler))
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/test")
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"))
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	assert.Equal(t, "strict-origin-when-cross-origin", resp.Header.Get("Referrer-Policy"))
+	assert.Equal(t, "1; mode=block", resp.Header.Get("X-XSS-Protection"))
+	// HSTS not set for HTTP
+	assert.Empty(t, resp.Header.Get("Strict-Transport-Security"))
+	// CSP and Permissions-Policy not set by default
+	assert.Empty(t, resp.Header.Get("Content-Security-Policy"))
+	assert.Empty(t, resp.Header.Get("Permissions-Policy"))
+}
+
+func TestSecure_HSTS_HTTPS(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("HSTS via TLS connection", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.TLS = &tls.ConnectionState{} // simulate TLS connection
+		w := httptest.NewRecorder()
+
+		Secure()(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "max-age=31536000; includeSubDomains", resp.Header.Get("Strict-Transport-Security"))
+	})
+
+	t.Run("HSTS via X-Forwarded-Proto", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.Header.Set("X-Forwarded-Proto", "https")
+		w := httptest.NewRecorder()
+
+		Secure()(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "max-age=31536000; includeSubDomains", resp.Header.Get("Strict-Transport-Security"))
+	})
+
+	t.Run("HSTS via Forwarded header", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.Header.Set("Forwarded", "proto=https")
+		w := httptest.NewRecorder()
+
+		Secure()(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "max-age=31536000; includeSubDomains", resp.Header.Get("Strict-Transport-Security"))
+	})
+
+	t.Run("no HSTS for HTTP", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		w := httptest.NewRecorder()
+
+		Secure()(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("Strict-Transport-Security"))
+	})
+}
+
+func TestSecure_CustomOptions(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("custom frame options", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		w := httptest.NewRecorder()
+
+		Secure(SecFrameOptions("SAMEORIGIN"))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "SAMEORIGIN", resp.Header.Get("X-Frame-Options"))
+	})
+
+	t.Run("disable content type nosniff", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		w := httptest.NewRecorder()
+
+		Secure(SecContentTypeNosniff(false))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("X-Content-Type-Options"))
+	})
+
+	t.Run("custom referrer policy", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		w := httptest.NewRecorder()
+
+		Secure(SecReferrerPolicy("no-referrer"))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "no-referrer", resp.Header.Get("Referrer-Policy"))
+	})
+
+	t.Run("custom CSP", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		w := httptest.NewRecorder()
+
+		csp := "default-src 'self'; script-src 'self'"
+		Secure(SecContentSecurityPolicy(csp))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, csp, resp.Header.Get("Content-Security-Policy"))
+	})
+
+	t.Run("custom permissions policy", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		w := httptest.NewRecorder()
+
+		pp := "geolocation=(), camera=()"
+		Secure(SecPermissionsPolicy(pp))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, pp, resp.Header.Get("Permissions-Policy"))
+	})
+
+	t.Run("custom HSTS", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.TLS = &tls.ConnectionState{}
+		w := httptest.NewRecorder()
+
+		Secure(SecHSTS(86400, false, true))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Equal(t, "max-age=86400; preload", resp.Header.Get("Strict-Transport-Security"))
+	})
+
+	t.Run("disable HSTS", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.TLS = &tls.ConnectionState{}
+		w := httptest.NewRecorder()
+
+		Secure(SecHSTS(0, false, false))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("Strict-Transport-Security"))
+	})
+
+	t.Run("disable XSS protection", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		w := httptest.NewRecorder()
+
+		Secure(SecXSSProtection(""))(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		assert.Empty(t, resp.Header.Get("X-XSS-Protection"))
+	})
+}
+
+func TestSecure_AllHeaders(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	req.TLS = &tls.ConnectionState{}
+	w := httptest.NewRecorder()
+
+	Secure(SecAllHeaders())(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	// default headers
+	assert.Equal(t, "DENY", resp.Header.Get("X-Frame-Options"))
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+	assert.Equal(t, "strict-origin-when-cross-origin", resp.Header.Get("Referrer-Policy"))
+	assert.Equal(t, "1; mode=block", resp.Header.Get("X-XSS-Protection"))
+	assert.Contains(t, resp.Header.Get("Strict-Transport-Security"), "max-age=31536000")
+
+	// additional headers from SecAllHeaders
+	csp := resp.Header.Get("Content-Security-Policy")
+	assert.Contains(t, csp, "default-src 'self'")
+	assert.Contains(t, csp, "script-src 'self'")
+	assert.Contains(t, csp, "frame-ancestors 'none'")
+
+	pp := resp.Header.Get("Permissions-Policy")
+	assert.Contains(t, pp, "geolocation=()")
+	assert.Contains(t, pp, "microphone=()")
+	assert.Contains(t, pp, "camera=()")
+}
+
+func TestSecure_MultipleOptions(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	req := httptest.NewRequest("GET", "/test", http.NoBody)
+	req.TLS = &tls.ConnectionState{}
+	w := httptest.NewRecorder()
+
+	Secure(
+		SecFrameOptions("SAMEORIGIN"),
+		SecReferrerPolicy("same-origin"),
+		SecHSTS(3600, true, false),
+		SecContentSecurityPolicy("default-src 'none'"),
+	)(handler).ServeHTTP(w, req)
+	resp := w.Result()
+	defer resp.Body.Close()
+
+	assert.Equal(t, "SAMEORIGIN", resp.Header.Get("X-Frame-Options"))
+	assert.Equal(t, "same-origin", resp.Header.Get("Referrer-Policy"))
+	assert.Equal(t, "max-age=3600; includeSubDomains", resp.Header.Get("Strict-Transport-Security"))
+	assert.Equal(t, "default-src 'none'", resp.Header.Get("Content-Security-Policy"))
+	// defaults still applied
+	assert.Equal(t, "nosniff", resp.Header.Get("X-Content-Type-Options"))
+}
+
+func TestIsHTTPS(t *testing.T) {
+	tests := []struct {
+		name     string
+		setup    func(*http.Request)
+		expected bool
+	}{
+		{name: "plain http", setup: func(r *http.Request) {}, expected: false},
+		{name: "tls connection", setup: func(r *http.Request) { r.TLS = &tls.ConnectionState{} }, expected: true},
+		{name: "x-forwarded-proto https", setup: func(r *http.Request) { r.Header.Set("X-Forwarded-Proto", "https") }, expected: true},
+		{name: "x-forwarded-proto http", setup: func(r *http.Request) { r.Header.Set("X-Forwarded-Proto", "http") }, expected: false},
+		{name: "x-forwarded-proto HTTPS uppercase", setup: func(r *http.Request) { r.Header.Set("X-Forwarded-Proto", "HTTPS") }, expected: true},
+		{name: "forwarded proto=https", setup: func(r *http.Request) { r.Header.Set("Forwarded", "proto=https") }, expected: true},
+		{name: "forwarded with semicolon", setup: func(r *http.Request) { r.Header.Set("Forwarded", "for=1.2.3.4;proto=https") }, expected: true},
+		{name: "forwarded with comma", setup: func(r *http.Request) { r.Header.Set("Forwarded", "for=1.2.3.4, proto=https") }, expected: true},
+		{name: "forwarded proto=http", setup: func(r *http.Request) { r.Header.Set("Forwarded", "proto=http") }, expected: false},
+		{name: "forwarded PROTO=HTTPS uppercase", setup: func(r *http.Request) { r.Header.Set("Forwarded", "PROTO=HTTPS") }, expected: true},
+		{name: "forwarded complex", setup: func(r *http.Request) { r.Header.Set("Forwarded", "for=192.0.2.60;proto=https;by=203.0.113.43") }, expected: true},
+		{name: "forwarded multiple elements", setup: func(r *http.Request) { r.Header.Set("Forwarded", "for=1.1.1.1;proto=http, for=2.2.2.2;proto=https") }, expected: true},
+		{name: "forwarded with spaces", setup: func(r *http.Request) { r.Header.Set("Forwarded", "for=1.2.3.4; proto=https") }, expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", "/test", http.NoBody)
+			tt.setup(req)
+			assert.Equal(t, tt.expected, isHTTPS(req))
+		})
+	}
+}
+
+func TestForwardedProtoIsHTTPS(t *testing.T) {
+	tests := []struct {
+		name     string
+		header   string
+		expected bool
+	}{
+		{name: "simple proto=https", header: "proto=https", expected: true},
+		{name: "simple proto=http", header: "proto=http", expected: false},
+		{name: "uppercase PROTO=HTTPS", header: "PROTO=HTTPS", expected: true},
+		{name: "mixed case Proto=Https", header: "Proto=Https", expected: true},
+		{name: "with for directive", header: "for=192.0.2.60;proto=https", expected: true},
+		{name: "full rfc example", header: "for=192.0.2.60;proto=https;by=203.0.113.43", expected: true},
+		{name: "multiple proxies first http", header: "for=1.1.1.1;proto=http, for=2.2.2.2;proto=https", expected: true},
+		{name: "multiple proxies all http", header: "for=1.1.1.1;proto=http, for=2.2.2.2;proto=http", expected: false},
+		{name: "with spaces", header: "for=1.2.3.4; proto=https ; by=proxy", expected: true},
+		{name: "proto at start", header: "proto=https;for=1.2.3.4", expected: true},
+		{name: "proto at end", header: "for=1.2.3.4;by=proxy;proto=https", expected: true},
+		{name: "empty string", header: "", expected: false},
+		{name: "no proto", header: "for=1.2.3.4;by=proxy", expected: false},
+		{name: "proto value with trailing space", header: "proto=https ", expected: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, forwardedProtoIsHTTPS(tt.header))
+		})
+	}
+}


### PR DESCRIPTION
**New middlewares for common security and URL normalization needs:**

- **Secure** - adds security headers (X-Frame-Options, X-Content-Type-Options, Referrer-Policy, HSTS, CSP, etc.)
- **CORS** - cross-origin resource sharing with configurable origins, methods, headers, and credentials support
- **CSRF** - cross-site request forgery protection using Fetch metadata headers (wraps stdlib on Go 1.25+)
- **CleanPath** - removes double slashes from URL paths while preserving encoding
- **StripSlashes** - removes trailing slashes from URL paths

All middlewares follow functional options pattern for configuration. Full test coverage (96.9%) and documentation included.