### PR TITLE
fix: add Access-Control-Request-* to Vary on CORS preflight

### DIFF
--- a/README.md
+++ b/README.md
@@ -213,6 +213,7 @@ Features:
 - Origin validation with case-insensitive matching
 - Credentials support (reflects origin instead of `*`)
 - Configurable cache duration for preflight results
+- Cache-correct `Vary` headers (adds `Access-Control-Request-Method` and `Access-Control-Request-Headers` on preflight)
 
 Available options:
 - `CorsAllowedOrigins(origins...)` - allowed origins (default: `*`)

--- a/cors.go
+++ b/cors.go
@@ -158,6 +158,9 @@ func CORS(opts ...CorsOpt) func(http.Handler) http.Handler {
 			// handle preflight request
 			if r.Method == http.MethodOptions && r.Header.Get("Access-Control-Request-Method") != "" {
 				// preflight request
+				// the response varies by the requested method and headers, so caches must key on them
+				w.Header().Add("Vary", "Access-Control-Request-Method")
+				w.Header().Add("Vary", "Access-Control-Request-Headers")
 				w.Header().Set("Access-Control-Allow-Methods", methodsStr)
 				w.Header().Set("Access-Control-Allow-Headers", headersStr)
 

--- a/cors_test.go
+++ b/cors_test.go
@@ -226,6 +226,59 @@ func TestCORS_VaryHeader(t *testing.T) {
 	assert.Contains(t, resp.Header.Get("Vary"), "Origin")
 }
 
+func TestCORS_PreflightVaryHeaders(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+
+	t.Run("preflight varies on origin, method and headers", func(t *testing.T) {
+		req := httptest.NewRequest("OPTIONS", "/test", http.NoBody)
+		req.Header.Set("Origin", "https://example.com")
+		req.Header.Set("Access-Control-Request-Method", "POST")
+		w := httptest.NewRecorder()
+
+		CORS()(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		vary := resp.Header.Values("Vary")
+		assert.Contains(t, vary, "Origin")
+		assert.Contains(t, vary, "Access-Control-Request-Method")
+		assert.Contains(t, vary, "Access-Control-Request-Headers")
+	})
+
+	t.Run("simple request does not vary on preflight headers", func(t *testing.T) {
+		req := httptest.NewRequest("GET", "/test", http.NoBody)
+		req.Header.Set("Origin", "https://example.com")
+		w := httptest.NewRecorder()
+
+		CORS()(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		vary := resp.Header.Values("Vary")
+		assert.Contains(t, vary, "Origin")
+		assert.NotContains(t, vary, "Access-Control-Request-Method")
+		assert.NotContains(t, vary, "Access-Control-Request-Headers")
+	})
+
+	t.Run("non-preflight OPTIONS does not vary on preflight headers", func(t *testing.T) {
+		// OPTIONS without Access-Control-Request-Method is not a preflight
+		req := httptest.NewRequest("OPTIONS", "/test", http.NoBody)
+		req.Header.Set("Origin", "https://example.com")
+		w := httptest.NewRecorder()
+
+		CORS()(handler).ServeHTTP(w, req)
+		resp := w.Result()
+		defer resp.Body.Close()
+
+		vary := resp.Header.Values("Vary")
+		assert.Contains(t, vary, "Origin")
+		assert.NotContains(t, vary, "Access-Control-Request-Method")
+		assert.NotContains(t, vary, "Access-Control-Request-Headers")
+	})
+}
+
 func TestCORS_OptionsWithoutPreflight(t *testing.T) {
 	handlerCalled := false
 	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {

--- a/logger/logger.go
+++ b/logger/logger.go
@@ -146,8 +146,8 @@ func (l *Middleware) formatDefault(r *http.Request, p *logParts) string {
 		_, _ = bld.WriteString(" ")
 	}
 
-	_, _ = bld.WriteString(fmt.Sprintf("%s - %s - %s - %s - %d (%d) - %v",
-		p.method, p.rawURL, p.host, p.remoteIP, p.statusCode, p.respSize, p.duration))
+	_, _ = fmt.Fprintf(&bld, "%s - %s - %s - %s - %d (%d) - %v",
+		p.method, p.rawURL, p.host, p.remoteIP, p.statusCode, p.respSize, p.duration)
 
 	if p.user != "" {
 		_, _ = bld.WriteString(" - ")

--- a/middleware.go
+++ b/middleware.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"os"
 	"runtime/debug"
+	"slices"
 	"strings"
 
 	"github.com/go-pkgz/rest/logger"
@@ -13,8 +14,8 @@ import (
 
 // Wrap converts a list of middlewares to nested calls (in reverse order)
 func Wrap(handler http.Handler, mws ...func(http.Handler) http.Handler) http.Handler {
-	for i := len(mws) - 1; i >= 0; i-- {
-		handler = mws[i](handler)
+	for _, mw := range slices.Backward(mws) {
+		handler = mw(handler)
 	}
 	return handler
 }


### PR DESCRIPTION
## Problem

`rest.CORS` sets `Vary: Origin` on every CORS response, but on a **preflight** response it should also vary on the requested method and headers. Without that, a shared cache or proxy may serve a single cached preflight response for requests that differ in `Access-Control-Request-Method` / `Access-Control-Request-Headers`, returning the wrong `Access-Control-Allow-*` set.

## Fix

On the preflight path only (`OPTIONS` with `Access-Control-Request-Method` set), add:

```go
w.Header().Add("Vary", "Access-Control-Request-Method")
w.Header().Add("Vary", "Access-Control-Request-Headers")
```

`Add` is used so the existing `Vary: Origin` field is preserved. Non-preflight responses are unchanged — they still only get `Vary: Origin`.

This brings the behaviour in line with [rs/cors](https://github.com/rs/cors) and [go-chi/cors](https://github.com/go-chi/cors), both of which emit all three `Vary` values on preflight.

## Tests

`TestCORS_PreflightVaryHeaders` asserts a preflight response carries all three `Vary` values, and that a simple (non-`OPTIONS`) request and a non-preflight `OPTIONS` request do **not** get the two preflight `Vary` values.

Found while migrating [umputun/remark42](https://github.com/umputun/remark42) (PR #2102) off go-chi onto go-pkgz/rest — remark42 currently works around this by wrapping `rest.CORS`.
