### PR TITLE
feat: add Timeout middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,14 @@ RealIP is a middleware that sets a http.Request's RemoteAddr to the results of p
 
 Only public IPs are accepted from headers; private/loopback/link-local IPs are skipped. This makes the middleware compatible with CDN setups like Cloudflare where the leftmost IP in `X-Forwarded-For` is the actual client.
 
+### Timeout middleware
+
+Timeout bounds a request to the given duration and responds with `StatusGatewayTimeout` (504) at the deadline if the handler has not finished — even for a handler that does not observe the context. The handler runs with a context deadline and its output is buffered; on success the buffered response is written through unchanged, and if the deadline fires first the buffered output is discarded, a 504 is sent, and further writes by the still-running handler return `http.ErrHandlerTimeout`. Because the response is buffered, `http.Flusher` and `http.Hijacker` are not available under `Timeout` (as with `net/http.TimeoutHandler`), so it is not suitable for streaming or connection-hijacking handlers. A non-positive duration disables the middleware (the handler is called directly).
+
+```go
+router.Use(rest.Timeout(5 * time.Second))
+```
+
 ### CORS middleware
 
 Handles Cross-Origin Resource Sharing, allowing controlled access from different origins.

--- a/timeout.go
+++ b/timeout.go
@@ -1,0 +1,133 @@
+package rest
+
+import (
+	"bytes"
+	"context"
+	"maps"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Timeout is a middleware that enforces a maximum duration for handling a request.
+// It runs the next handler with a context deadline and, if the handler has not finished
+// by the time the deadline is reached, responds with StatusGatewayTimeout (504) at the
+// deadline — regardless of whether the handler observes the context.
+//
+// The handler's output is buffered until it completes: on success the buffered response
+// (status, headers and body) is written through unchanged; if the deadline fires first,
+// the buffered output is discarded, a 504 is sent, and any further writes by the still
+// running handler return http.ErrHandlerTimeout. If the parent request context is
+// canceled (rather than the deadline being exceeded) the handler is stopped without a
+// 504, since the request is being abandoned, and its later writes return the context's
+// error (e.g. context.Canceled).
+//
+// Because the response is buffered, the wrapped ResponseWriter does not support
+// http.Flusher or http.Hijacker (matching net/http.TimeoutHandler); streaming and
+// connection hijacking are not available under Timeout.
+//
+// A non-positive timeout disables the middleware: the handler is called directly, with
+// no deadline, buffering or 504.
+func Timeout(timeout time.Duration) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		if timeout <= 0 {
+			return next
+		}
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx, cancel := context.WithTimeout(r.Context(), timeout)
+			defer cancel()
+			r = r.WithContext(ctx)
+
+			done := make(chan struct{})
+			panicChan := make(chan any, 1)
+			tw := &timeoutWriter{w: w, h: make(http.Header)}
+
+			go func() {
+				defer func() {
+					if p := recover(); p != nil {
+						panicChan <- p
+					}
+				}()
+				next.ServeHTTP(tw, r)
+				close(done)
+			}()
+
+			select {
+			case p := <-panicChan:
+				panic(p)
+			case <-done:
+				tw.mu.Lock()
+				defer tw.mu.Unlock()
+				maps.Copy(w.Header(), tw.h)
+				code := http.StatusOK
+				if tw.wroteHeader {
+					code = tw.code
+				}
+				w.WriteHeader(code)
+				_, _ = w.Write(tw.wbuf.Bytes())
+			case <-ctx.Done():
+				tw.mu.Lock()
+				defer tw.mu.Unlock()
+				// discard the buffer and stop further handler writes, recording the cause so a
+				// late write returns the real error. Only the deadline yields a 504; a canceled
+				// parent means the request is being abandoned, so there is nobody to send it to.
+				switch err := ctx.Err(); err {
+				case context.DeadlineExceeded:
+					tw.err = http.ErrHandlerTimeout
+					w.WriteHeader(http.StatusGatewayTimeout)
+				default:
+					tw.err = err
+				}
+			}
+		})
+	}
+}
+
+// timeoutWriter buffers a handler's response so the Timeout middleware can either flush
+// it on success or discard it and send a 504 once the deadline is reached. All fields
+// after mu are guarded by mu, which is also held by the middleware while it drains the
+// buffer, so it is safe against a handler goroutine that keeps writing after the timeout.
+type timeoutWriter struct {
+	w http.ResponseWriter
+	h http.Header
+
+	mu          sync.Mutex
+	wbuf        bytes.Buffer
+	code        int
+	wroteHeader bool
+	err         error // set once the response is timed out or canceled; returned by Write
+}
+
+// Header implements http.ResponseWriter and returns the buffered header map.
+func (tw *timeoutWriter) Header() http.Header { return tw.h }
+
+// Write implements http.ResponseWriter, buffering the response body. Once the response has
+// timed out or been canceled it buffers nothing and returns the recorded error
+// (http.ErrHandlerTimeout on deadline, or the context error on cancellation).
+func (tw *timeoutWriter) Write(p []byte) (int, error) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	if tw.err != nil {
+		return 0, tw.err
+	}
+	if !tw.wroteHeader {
+		tw.setHeaderLocked(http.StatusOK)
+	}
+	return tw.wbuf.Write(p)
+}
+
+// WriteHeader implements http.ResponseWriter, recording the status for the buffered
+// response. It is a no-op after the timeout has fired or after the first call.
+func (tw *timeoutWriter) WriteHeader(code int) {
+	tw.mu.Lock()
+	defer tw.mu.Unlock()
+	tw.setHeaderLocked(code)
+}
+
+func (tw *timeoutWriter) setHeaderLocked(code int) {
+	if tw.err != nil || tw.wroteHeader {
+		return
+	}
+	tw.wroteHeader = true
+	tw.code = code
+}

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -1,0 +1,217 @@
+package rest
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestTimeout(t *testing.T) {
+	t.Run("fast handler passes through status, headers and body", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("X-Custom", "value")
+			w.WriteHeader(http.StatusCreated)
+			_, _ = w.Write([]byte("ok"))
+		})
+
+		rec := httptest.NewRecorder()
+		Timeout(time.Second)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+
+		assert.Equal(t, http.StatusCreated, rec.Code)
+		assert.Equal(t, "ok", rec.Body.String())
+		assert.Equal(t, "value", rec.Header().Get("X-Custom"))
+	})
+
+	t.Run("handler without explicit status defaults to 200", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write([]byte("body"))
+		})
+
+		rec := httptest.NewRecorder()
+		Timeout(time.Second)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+
+		assert.Equal(t, http.StatusOK, rec.Code)
+		assert.Equal(t, "body", rec.Body.String())
+	})
+
+	t.Run("context carries the deadline", func(t *testing.T) {
+		var hasDeadline bool
+		handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			_, hasDeadline = r.Context().Deadline()
+		})
+
+		rec := httptest.NewRecorder()
+		Timeout(time.Second)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+		assert.True(t, hasDeadline, "handler should see a context deadline")
+	})
+
+	t.Run("non-positive timeout disables the middleware", func(t *testing.T) {
+		for _, d := range []time.Duration{0, -time.Second} {
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, hasDeadline := r.Context().Deadline()
+				assert.False(t, hasDeadline, "a disabled timeout must not set a deadline")
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte("ok"))
+			})
+
+			rec := httptest.NewRecorder()
+			Timeout(d)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+			assert.Equal(t, http.StatusOK, rec.Code)
+			assert.Equal(t, "ok", rec.Body.String())
+		}
+	})
+
+	t.Run("handler ignoring the context is timed out at the deadline", func(t *testing.T) {
+		release := make(chan struct{})
+		handlerDone := make(chan struct{})
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			defer close(handlerDone)
+			<-release // ignores the request context entirely
+			_, _ = w.Write([]byte("late"))
+		})
+
+		rec := httptest.NewRecorder()
+		start := time.Now()
+		Timeout(20*time.Millisecond)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+		elapsed := time.Since(start)
+
+		assert.Equal(t, http.StatusGatewayTimeout, rec.Code)
+		assert.Empty(t, rec.Body.String(), "the handler's buffered output must be discarded")
+		assert.Less(t, elapsed, 2*time.Second, "ServeHTTP must return at the deadline, not wait for the handler")
+
+		close(release)
+		<-handlerDone
+	})
+
+	t.Run("handler respecting the context times out", func(t *testing.T) {
+		handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			<-r.Context().Done()
+		})
+
+		rec := httptest.NewRecorder()
+		Timeout(20*time.Millisecond)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+		assert.Equal(t, http.StatusGatewayTimeout, rec.Code)
+	})
+
+	t.Run("partially written response is discarded on timeout", func(t *testing.T) {
+		release := make(chan struct{})
+		handlerDone := make(chan struct{})
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			defer close(handlerDone)
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte("partial"))
+			<-release
+		})
+
+		rec := httptest.NewRecorder()
+		Timeout(20*time.Millisecond)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+
+		assert.Equal(t, http.StatusGatewayTimeout, rec.Code)
+		assert.Empty(t, rec.Body.String(), "buffered partial output must not leak after a timeout")
+
+		close(release)
+		<-handlerDone
+	})
+
+	t.Run("writes after the timeout return ErrHandlerTimeout", func(t *testing.T) {
+		release := make(chan struct{})
+		handlerDone := make(chan struct{})
+		var writeErr error
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			defer close(handlerDone)
+			<-release // resumes only after the timeout has fired
+			_, writeErr = w.Write([]byte("late"))
+		})
+
+		rec := httptest.NewRecorder()
+		Timeout(20*time.Millisecond)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+		assert.Equal(t, http.StatusGatewayTimeout, rec.Code)
+
+		close(release)
+		<-handlerDone
+		assert.ErrorIs(t, writeErr, http.ErrHandlerTimeout)
+	})
+
+	t.Run("duplicate WriteHeader keeps the first status", func(t *testing.T) {
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			w.WriteHeader(http.StatusBadRequest) // ignored
+		})
+
+		rec := httptest.NewRecorder()
+		Timeout(time.Second)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+		assert.Equal(t, http.StatusCreated, rec.Code)
+	})
+
+	t.Run("WriteHeader after the timeout is a no-op", func(t *testing.T) {
+		release := make(chan struct{})
+		handlerDone := make(chan struct{})
+		handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			defer close(handlerDone)
+			<-release // resumes only after the timeout has fired
+			w.WriteHeader(http.StatusTeapot)
+		})
+
+		rec := httptest.NewRecorder()
+		Timeout(20*time.Millisecond)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+		assert.Equal(t, http.StatusGatewayTimeout, rec.Code)
+
+		close(release)
+		<-handlerDone
+	})
+
+	t.Run("handler panic propagates", func(t *testing.T) {
+		handler := http.HandlerFunc(func(http.ResponseWriter, *http.Request) {
+			panic("boom")
+		})
+
+		rec := httptest.NewRecorder()
+		assert.PanicsWithValue(t, "boom", func() {
+			Timeout(time.Second)(handler).ServeHTTP(rec, httptest.NewRequest("GET", "/", http.NoBody))
+		})
+	})
+
+	t.Run("cancelled parent context stops the handler without a 504", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		handlerDone := make(chan struct{})
+		handler := http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+			defer close(handlerDone)
+			<-r.Context().Done()
+		})
+
+		req := httptest.NewRequest("GET", "/", http.NoBody).WithContext(ctx)
+		rec := httptest.NewRecorder()
+		cancel() // parent is cancelled, not timed out
+
+		Timeout(time.Second)(handler).ServeHTTP(rec, req)
+		<-handlerDone
+		assert.NotEqual(t, http.StatusGatewayTimeout, rec.Code, "parent cancellation must not send a 504")
+	})
+
+	t.Run("writes after parent cancellation return the context error", func(t *testing.T) {
+		ctx, cancel := context.WithCancel(context.Background())
+		handlerDone := make(chan struct{})
+		var writeErr error
+		handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			defer close(handlerDone)
+			<-r.Context().Done()
+			// the middleware records the cancellation cause under the writer's lock; retry
+			// until a write is rejected so the assertion doesn't race that bookkeeping
+			for writeErr == nil {
+				_, writeErr = w.Write([]byte("x"))
+			}
+		})
+
+		req := httptest.NewRequest("GET", "/", http.NoBody).WithContext(ctx)
+		cancel()
+		Timeout(time.Second)(handler).ServeHTTP(httptest.NewRecorder(), req)
+		<-handlerDone
+
+		assert.ErrorIs(t, writeErr, context.Canceled, "a write after parent cancellation must return the context error")
+		assert.NotErrorIs(t, writeErr, http.ErrHandlerTimeout, "cancellation must not be reported as a handler timeout")
+	})
+}


### PR DESCRIPTION
## Summary

go-pkgz/rest has `Throttle`, `RealIP`, `NoCache`, `CORS`, `Recoverer` and friends, but no `Timeout` middleware, so consumers hand-roll one. This adds `Timeout`.

```go
func Timeout(timeout time.Duration) func(http.Handler) http.Handler
```

It **enforces** a maximum request duration, modeled on `net/http.TimeoutHandler`: the next handler runs in a goroutine with a context deadline, and if it has not finished by the deadline the middleware responds with `StatusGatewayTimeout` (504) **at the deadline** — even for a handler that ignores the context.

The handler's output is buffered and written through on success; if the deadline fires first the buffered output is discarded, a 504 is sent, and further handler writes return `http.ErrHandlerTimeout`. A canceled parent context stops the handler without sending a 504, and panics propagate. Because the response is buffered, `http.Flusher` and `http.Hijacker` are not available under `Timeout` (same trade-off as `net/http.TimeoutHandler`).

## Tests

`TestTimeout` (subtests, millisecond deadlines, `-race` clean, 100% coverage of timeout.go) covers: fast pass-through with status/headers/body; default 200; the context carrying the deadline; a context-ignoring handler timed out **at** the deadline (output discarded); a context-respecting handler timing out; partial output discarded on timeout; post-timeout writes returning `http.ErrHandlerTimeout`; duplicate/after-timeout `WriteHeader` no-ops; panic propagation; and canceled-parent-context stopping the handler without a 504.

Found while migrating [umputun/remark42](https://github.com/umputun/remark42) off go-chi onto go-pkgz/rest.